### PR TITLE
fix: Prevent duplicate upstream sync issues

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -184,6 +184,28 @@ jobs:
             const commitCount = '${{ steps.check.outputs.commit_count }}' || '?';
             const upstreamCommit = '${{ steps.check.outputs.upstream_commit }}';
 
+            // 중복 이슈 방지: 동일한 upstream 커밋을 추적하는 열린 이슈가 있는지 확인
+            const existingIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'upstream,sync',
+              state: 'open',
+              sort: 'created',
+              direction: 'desc',
+              per_page: 1
+            });
+
+            if (existingIssues.data.length > 0) {
+              const lastIssue = existingIssues.data[0];
+              const commitMatch = lastIssue.body.match(/최신 커밋.*`([a-f0-9]{7,})`/);
+              const lastDetectedCommit = commitMatch?.[1];
+
+              if (lastDetectedCommit && upstreamCommit.startsWith(lastDetectedCommit)) {
+                console.log(`Skipped: upstream commit unchanged, already tracked by issue #${lastIssue.number}`);
+                return;
+              }
+            }
+
             let title = '🔄 Upstream 업데이트: ';
             const parts = [];
             if (hasNew) parts.push(`새 패턴 ${newCount}개`);


### PR DESCRIPTION
## Summary
- upstream 커밋이 변경되지 않았을 때 중복 이슈 생성을 방지
- 최신 열린 이슈의 upstream 커밋 해시와 현재 커밋을 비교하여 동일하면 스킵
- upstream에 실제 새 커밋이 있을 때만 새 이슈 생성

## Test plan
- [ ] upstream 변경 없이 workflow 수동 실행 → 이슈 생성 안 됨 확인
- [ ] upstream 변경 후 workflow 실행 → 새 이슈 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)