### PR TITLE
feat: Update 10 patterns from upstream (batch 6)

### DIFF
--- a/src/data/patterns/compounding-engineering-pattern.json
+++ b/src/data/patterns/compounding-engineering-pattern.json
@@ -6,27 +6,59 @@
   "status": "emerging",
   "original_url": "https://every.to/podcast/transcript-how-to-use-claude-code-like-the-people-who-built-it",
   "problem": {
-    "en": "Traditional software engineering has diminishing returns: each feature increases complexity. With AI agents, this is amplified as agents repeat the same mistakes because learnings aren't captured.",
-    "ko": "전통적인 소프트웨어 엔지니어링은 수확 체감이 있습니다: 각 기능이 복잡성을 증가시킵니다. AI 에이전트에서는 학습이 캡처되지 않아 에이전트가 같은 실수를 반복하므로 이 문제가 증폭됩니다."
+    "en": "Traditional software engineering has diminishing returns: each feature added increases complexity, making subsequent features harder to build. Technical debt accumulates, onboarding takes longer, and new team members struggle to be productive.\n\nWith AI coding agents, this problem is amplified—agents make the same mistakes repeatedly because learnings aren't systematically captured and codified.",
+    "ko": "전통적인 소프트웨어 엔지니어링은 수확 체감의 법칙을 따릅니다: 추가되는 각 기능이 복잡성을 증가시켜 후속 기능 개발을 더 어렵게 만듭니다. 기술 부채가 누적되고, 온보딩 기간이 길어지며, 새 팀원이 생산적으로 되기 어렵습니다.\n\nAI 코딩 에이전트에서는 이 문제가 증폭됩니다. 학습 내용이 체계적으로 캡처되고 코드화되지 않으므로 에이전트가 동일한 실수를 반복합니다."
   },
   "solution": {
-    "en": "Make each feature compound by codifying all learnings into reusable agent instructions: system prompts, slash commands, subagents, and hooks.",
-    "ko": "모든 학습 내용을 재사용 가능한 에이전트 지침(시스템 프롬프트, 슬래시 명령, 서브에이전트, 훅)으로 코드화하여 각 기능을 복합적으로 만듭니다."
+    "en": "Flip the equation: make each feature compound by codifying all learnings into reusable agent instructions. When you complete a feature, document:\n\n1. **What worked in the plan** and what needed adjustment\n2. **Issues discovered during testing** that weren't caught earlier\n3. **Common mistakes** the agent made\n4. **Patterns and best practices** that should be reused\n\nThen embed these insights into:\n\n- **Claude MD / system prompts**: Global coding standards\n- **Slash commands**: Repeatable workflows (e.g., `/test-with-validation`)\n- **Subagents**: Specialized validators (e.g., security review agent)\n- **Hooks**: Automated checks that prevent regressions\n\n**Result**: Each feature makes the next easier because the codebase becomes increasingly \"self-teaching.\"",
+    "ko": "방정식을 뒤집습니다: 모든 학습 내용을 재사용 가능한 에이전트 지침으로 코드화하여 각 기능을 복합적으로 만듭니다. 기능을 완료하면 다음을 문서화합니다:\n\n1. **계획에서 효과가 있었던 것**과 조정이 필요했던 것\n2. **테스트 중 발견된 문제**로 이전에 포착되지 않은 것\n3. **에이전트가 저지른 일반적인 실수**\n4. **재사용해야 할 패턴과 모범 사례**\n\n그런 다음 이러한 인사이트를 다음에 내장합니다:\n\n- **Claude MD / 시스템 프롬프트**: 글로벌 코딩 표준\n- **슬래시 명령**: 반복 가능한 워크플로우 (예: `/test-with-validation`)\n- **서브에이전트**: 전문화된 검증기 (예: 보안 리뷰 에이전트)\n- **훅**: 회귀를 방지하는 자동화된 검사\n\n**결과**: 코드베이스가 점점 '자기 학습' 능력을 갖추게 되어 각 기능이 다음 기능을 더 쉽게 만듭니다."
   },
   "ascii_diagram": "┌─────────────┐\n│Build Feature│\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│  Document   │\n│  Learnings  │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│Codify into: │\n├─────────────┤\n│• Prompts    │\n│• Commands   │\n│• Subagents  │\n│• Hooks      │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│ Next Build  │\n│  (Easier!)  │\n└─────────────┘",
   "mermaid_diagram": "graph LR\n    A[Build Feature] --> B[Document Learnings]\n    B --> C[Codify into Prompts/Commands]\n    C --> D[Next Feature Uses Knowledge]\n    D --> E[Easier & Faster Build]\n    E --> A",
   "code_example": "# After completing a feature, codify learnings:\n\n# 1. Update CLAUDE.md with patterns\nwith open('CLAUDE.md', 'a') as f:\n    f.write('## API Error Handling\\n')\n    f.write('Always wrap external calls in retry logic...\\n')\n\n# 2. Create slash command for repeated workflow\n# .claude/commands/test-with-validation.md\ncommand = '''\nRun tests with extra validation:\n1. Run unit tests\n2. Check for type errors\n3. Validate API contracts\n'''\n\n# 3. Add hook to prevent regressions\n# .claude/hooks/pre-commit.sh\nhook = 'npm run typecheck && npm test'\n\n# Result: Next features get this knowledge for free",
   "when_to_use": {
-    "en": ["Multi-feature development", "Team onboarding", "Long-running AI agent projects"],
-    "ko": ["다기능 개발", "팀 온보딩", "장기 AI 에이전트 프로젝트"]
+    "en": [
+      "During feature development: track what the agent got wrong, note plan revisions, document edge cases, identify repeated questions",
+      "After completion: update CLAUDE.md, create slash commands, build subagents for validation, add hooks, write tests that encode requirements",
+      "Works synergistically with Memory Synthesis from Execution Logs, Coding Agent CI Feedback Loop, and Skill Library Evolution"
+    ],
+    "ko": [
+      "기능 개발 중: 에이전트의 실수 추적, 계획 수정 기록, 엣지 케이스 문서화, 반복 질문 식별",
+      "완료 후: CLAUDE.md 업데이트, 슬래시 명령 생성, 검증용 서브에이전트 구축, 훅 추가, 요구사항을 인코딩하는 테스트 작성",
+      "Memory Synthesis from Execution Logs, Coding Agent CI Feedback Loop, Skill Library Evolution과 시너지 효과"
+    ]
   },
   "pros": {
-    "en": ["Accelerating productivity", "Knowledge preservation", "Better onboarding"],
-    "ko": ["생산성 가속화", "지식 보존", "더 나은 온보딩"]
+    "en": [
+      "Accelerating productivity: Each feature genuinely makes the next faster",
+      "Knowledge preservation: Learnings don't depend on individual memory",
+      "Better onboarding: New team members (human or AI) leverage accumulated knowledge",
+      "Reduced repetition: Agent stops making the same mistakes",
+      "Living documentation: Instructions stay current because they're used daily"
+    ],
+    "ko": [
+      "생산성 가속화: 각 기능이 진정으로 다음 기능을 더 빠르게 만듦",
+      "지식 보존: 학습 내용이 개인의 기억에 의존하지 않음",
+      "더 나은 온보딩: 새 팀원(인간 또는 AI)이 축적된 지식을 활용",
+      "반복 감소: 에이전트가 동일한 실수를 멈춤",
+      "살아있는 문서화: 매일 사용되므로 지침이 최신 상태 유지"
+    ]
   },
   "cons": {
-    "en": ["Upfront time investment", "Maintenance overhead", "Risk of over-specification"],
-    "ko": ["초기 시간 투자", "유지보수 오버헤드", "과도한 명세화 위험"]
+    "en": [
+      "Upfront time investment: Requires discipline to document after each feature",
+      "Maintenance overhead: Prompts and commands need updates as patterns change",
+      "Over-specification risk: Too many rules can make agents inflexible",
+      "Requires tooling: Needs extensible agent system (slash commands, hooks, etc.)",
+      "Prompt bloat: System prompts can grow large over time"
+    ],
+    "ko": [
+      "초기 시간 투자: 각 기능 완료 후 문서화하는 규율 필요",
+      "유지보수 오버헤드: 패턴 변경 시 프롬프트와 명령 업데이트 필요",
+      "과도한 명세화 위험: 너무 많은 규칙이 에이전트를 유연하지 못하게 만들 수 있음",
+      "도구 의존성: 확장 가능한 에이전트 시스템 필요 (슬래시 명령, 훅 등)",
+      "프롬프트 비대화: 시스템 프롬프트가 시간이 지남에 따라 커질 수 있음"
+    ]
   },
   "tags": ["learning", "feedback-loops", "codification", "prompts", "slash-commands"]
 }

--- a/src/data/patterns/context-minimization-pattern.json
+++ b/src/data/patterns/context-minimization-pattern.json
@@ -6,27 +6,47 @@
   "status": "emerging",
   "original_url": "https://arxiv.org/abs/2506.08837",
   "problem": {
-    "en": "User-supplied or tainted text lingers in context, enabling later prompt injection attacks.",
-    "ko": "사용자 제공 또는 오염된 텍스트가 컨텍스트에 남아 이후 프롬프트 인젝션 공격을 가능하게 합니다."
+    "en": "In long agent sessions, raw user text and tool outputs often remain in-context long after they are needed. If those tokens include adversarial instructions, they can silently bias later reasoning steps, even when the current step is unrelated. This creates delayed prompt-injection risk and unnecessary context bloat.",
+    "ko": "장시간 에이전트 세션에서 원시 사용자 텍스트와 도구 출력이 필요한 시점이 지난 후에도 종종 컨텍스트에 남아 있습니다. 해당 토큰에 적대적 지시사항이 포함되어 있으면, 현재 단계와 무관하더라도 이후 추론 단계에 은밀하게 편향을 줄 수 있습니다. 이는 지연된 프롬프트 인젝션 위험과 불필요한 컨텍스트 비대를 초래합니다."
   },
   "solution": {
-    "en": "Purge or redact untrusted segments once they've served their purpose, keeping context clean.",
-    "ko": "신뢰할 수 없는 세그먼트가 목적을 달성하면 제거하거나 수정하여 컨텍스트를 깨끗하게 유지합니다."
+    "en": "Purge or redact untrusted segments once they've served their purpose:\n\n- After transforming input into a safe intermediate (query, structured object), strip the original prompt from context.\n- Subsequent reasoning sees only trusted data, eliminating latent injections.\n- A strong variant also removes intermediate LLM outputs that may have been tainted.\n\nTreat context as a staged pipeline: ingest untrusted text, transform it, then aggressively discard the original tainted material. Keep only signed-off structured artifacts that downstream steps are allowed to consume.",
+    "ko": "신뢰할 수 없는 세그먼트가 목적을 달성하면 제거하거나 수정합니다:\n\n- 입력을 안전한 중간 형태(쿼리, 구조화된 객체)로 변환한 후, 원본 프롬프트를 컨텍스트에서 제거합니다.\n- 이후 추론은 신뢰할 수 있는 데이터만 보게 되어 잠재적 인젝션을 제거합니다.\n- 강력한 변형은 오염되었을 수 있는 중간 LLM 출력도 제거합니다.\n\n컨텍스트를 단계별 파이프라인으로 취급합니다: 신뢰할 수 없는 텍스트를 수집하고, 변환한 후, 원본 오염 자료를 적극적으로 폐기합니다. 다운스트림 단계가 소비할 수 있는 승인된 구조화된 아티팩트만 유지합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│User Prompt  │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│  Transform  │\n│  to SQL     │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│REMOVE tainted│\n│   tokens    │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│Safe context │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[User Input] --> B[Process/Transform]\n    B --> C[Remove Untrusted Tokens]\n    C --> D[Clean Context]\n    D --> E[Continue Safely]",
   "code_example": "# Transform user input to safe intermediate form\nsql = LLM('Convert to SQL', user_prompt)\n\n# Remove the untrusted input from context\ncontext.remove(user_prompt)\n\n# Execute with clean context\nrows = db.query(sql)",
   "when_to_use": {
-    "en": ["Customer service chatbots", "Medical Q&A systems", "Multi-turn flows with sensitive data"],
-    "ko": ["고객 서비스 챗봇", "의료 Q&A 시스템", "민감한 데이터가 있는 다중 턴 흐름"]
+    "en": [
+      "Customer-service chat, medical Q&A, database query generation, any multi-turn flow where initial text shouldn't steer later steps"
+    ],
+    "ko": [
+      "고객 서비스 채팅, 의료 Q&A, 데이터베이스 쿼리 생성 등 초기 텍스트가 이후 단계에 영향을 주지 않아야 하는 다중 턴 흐름"
+    ]
   },
   "pros": {
-    "en": ["Simple implementation", "No additional models needed", "Alleviates context anxiety"],
-    "ko": ["간단한 구현", "추가 모델 불필요", "컨텍스트 불안 완화"]
+    "en": [
+      "Simple; no extra models needed",
+      "Helps prevent context window anxiety by reducing overall context usage",
+      "Provides compliance benefits (HIPAA/GDPR data minimization)"
+    ],
+    "ko": [
+      "간단하며 추가 모델 불필요",
+      "전체 컨텍스트 사용량을 줄여 컨텍스트 윈도우 불안 방지에 도움",
+      "규정 준수 이점 제공 (HIPAA/GDPR 데이터 최소화)"
+    ]
   },
   "cons": {
-    "en": ["May lose conversational nuance", "Potential UX degradation"],
-    "ko": ["대화 뉘앙스 손실", "UX 저하 가능"]
+    "en": [
+      "Later turns lose conversational nuance; may hurt UX",
+      "Overly aggressive minimization can remove useful context",
+      "Risks broken referential coherence when earlier turns are referenced (\"the function I mentioned before\")"
+    ],
+    "ko": [
+      "이후 턴에서 대화 뉘앙스 손실; UX 저하 가능",
+      "과도한 최소화는 유용한 컨텍스트를 제거할 수 있음",
+      "이전 턴을 참조할 때 참조 일관성 깨질 위험 (\"앞서 언급한 함수\")"
+    ]
   },
   "tags": ["context-hygiene", "taint-removal", "prompt-injection", "security"]
 }

--- a/src/data/patterns/distributed-execution-cloud-workers.json
+++ b/src/data/patterns/distributed-execution-cloud-workers.json
@@ -6,27 +6,65 @@
   "status": "emerging",
   "original_url": "https://claude.com/blog/building-companies-with-claude-code",
   "problem": {
-    "en": "Single-session agent execution cannot scale for team-wide AI code generation workloads.",
-    "ko": "단일 세션 에이전트 실행은 팀 전체 AI 코드 생성 워크로드를 확장할 수 없습니다."
+    "en": "Single-session AI agent execution cannot scale to meet enterprise team demands. Complex projects require multiple simultaneous code changes across different parts of the codebase, but coordinating multiple agents introduces challenges around communication, conflict resolution, merge coordination, and infrastructure management.",
+    "ko": "단일 세션 AI 에이전트 실행은 기업 팀 요구를 충족하도록 확장할 수 없습니다. 복잡한 프로젝트는 코드베이스의 다양한 부분에서 동시에 여러 코드 변경을 필요로 하지만, 다수의 에이전트를 조정하면 통신, 충돌 해결, 병합 조정, 인프라 관리와 관련된 과제가 발생합니다."
   },
   "solution": {
-    "en": "Run multiple Claude sessions in parallel using git worktrees and cloud workers, coordinating via a central orchestrator.",
-    "ko": "git worktree와 클라우드 워커를 사용하여 여러 Claude 세션을 병렬로 실행하고, 중앙 오케스트레이터를 통해 조정합니다."
+    "en": "Implement a distributed execution framework that runs multiple Claude Code sessions in parallel using git worktrees and cloud-based worker infrastructure. This enables team-scale AI code generation with proper synchronization and conflict management.\n\nCore architecture:\n\n- Git worktrees for isolation: Each agent session runs in a dedicated worktree with shared Git object database (lightweight storage), independent indexes and working directories per agent, enabling parallel development without checkout conflicts.\n- Cloud worker deployment: Agent sessions execute on remote infrastructure, scaling horizontally based on workload with centralized task distribution and coordination.\n- Synchronization layer: Merge conflict detection and resolution, inter-agent communication protocols, shared state management for coordination, dependency-aware task scheduling (DAG-based), and work-stealing for load balancing.\n- Human oversight integration: Approval gates for risky operations, centralized monitoring dashboard, and team notification channels (Slack, email).",
+    "ko": "git worktree와 클라우드 기반 워커 인프라를 사용하여 여러 Claude Code 세션을 병렬로 실행하는 분산 실행 프레임워크를 구현합니다. 이를 통해 적절한 동기화 및 충돌 관리와 함께 팀 규모의 AI 코드 생성이 가능합니다.\n\n핵심 아키텍처:\n\n- 격리를 위한 Git worktree: 각 에이전트 세션이 전용 worktree에서 실행되며, 공유 Git 객체 데이터베이스(경량 저장소), 에이전트별 독립 인덱스와 작업 디렉토리로 체크아웃 충돌 없이 병렬 개발이 가능합니다.\n- 클라우드 워커 배포: 에이전트 세션이 원격 인프라에서 실행되며, 워크로드에 따라 수평 확장하고 중앙 집중식 작업 분배 및 조정을 합니다.\n- 동기화 레이어: 병합 충돌 감지 및 해결, 에이전트 간 통신 프로토콜, 조정을 위한 공유 상태 관리, 의존성 인식 작업 스케줄링(DAG 기반), 로드 밸런싱을 위한 작업 스틸링을 포함합니다.\n- 사람 감독 통합: 위험한 작업에 대한 승인 게이트, 중앙 집중식 모니터링 대시보드, 팀 알림 채널(Slack, 이메일)을 제공합니다."
   },
   "ascii_diagram": "┌────────────────────┐\n│   Coordinator      │\n└─────────┬──────────┘\n    ┌─────┼─────┐\n    ▼     ▼     ▼\n┌─────┐┌─────┐┌─────┐\n│W1   ││W2   ││W3   │\n│+tree││+tree││+tree│\n└──┬──┘└──┬──┘└──┬──┘\n   │      │      │\n   └──────┼──────┘\n          ▼\n     ┌─────────┐\n     │  Merge  │\n     └─────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Coordinator] --> B[Worker 1 + worktree]\n    A --> C[Worker 2 + worktree]\n    A --> D[Worker N + worktree]\n    B --> E[Branch 1]\n    C --> F[Branch 2]\n    D --> G[Branch N]\n    E & F & G --> H[Merge to Main]",
   "code_example": "# Create isolated worktrees for each worker\nfor i in range(num_workers):\n    worktree_path = f'/tmp/worktree-{i}'\n    git.worktree.add(worktree_path, f'worker-branch-{i}')\n    \n    # Spawn cloud worker with isolated environment\n    worker = cloud.spawn(\n        image='claude-agent',\n        mount=worktree_path\n    )\n    workers.append(worker)",
   "when_to_use": {
-    "en": ["Team-scale migrations", "Parallel feature development", "Large-scale refactoring"],
-    "ko": ["팀 규모 마이그레이션", "병렬 기능 개발", "대규모 리팩토링"]
+    "en": [
+      "Team-wide code migrations or refactoring",
+      "Parallel feature development across multiple services",
+      "Large-scale testing infrastructure changes",
+      "Framework upgrades affecting many files",
+      "Organizations with high AI agent adoption"
+    ],
+    "ko": [
+      "팀 전체 코드 마이그레이션 또는 리팩토링",
+      "여러 서비스에 걸친 병렬 기능 개발",
+      "대규모 테스트 인프라 변경",
+      "많은 파일에 영향을 미치는 프레임워크 업그레이드",
+      "AI 에이전트 도입이 활발한 조직"
+    ]
   },
   "pros": {
-    "en": ["Massive parallelization", "Team scalability", "Centralized management"],
-    "ko": ["대규모 병렬화", "팀 확장성", "중앙 집중 관리"]
+    "en": [
+      "Massive parallelization (10x-100x speedup for suitable tasks)",
+      "Scales to enterprise team needs",
+      "Centralizes agent management and monitoring",
+      "Enables team-wide AI adoption",
+      "Reduces bottlenecks in large migrations"
+    ],
+    "ko": [
+      "대규모 병렬화 (적합한 작업에 10x-100x 속도 향상)",
+      "기업 팀 요구에 맞게 확장",
+      "에이전트 관리 및 모니터링 중앙 집중화",
+      "팀 전체 AI 도입 가능",
+      "대규모 마이그레이션 병목 감소"
+    ]
   },
   "cons": {
-    "en": ["Infrastructure complexity", "Merge conflicts", "Higher costs"],
-    "ko": ["인프라 복잡성", "병합 충돌", "비용 증가"]
+    "en": [
+      "Significant infrastructure complexity",
+      "Merge conflict management overhead",
+      "Coordination logic development required",
+      "Higher cost from parallel model usage",
+      "Requires sophisticated orchestration system",
+      "Network latency for cloud workers"
+    ],
+    "ko": [
+      "상당한 인프라 복잡성",
+      "병합 충돌 관리 오버헤드",
+      "조정 로직 개발 필요",
+      "병렬 모델 사용으로 인한 높은 비용",
+      "정교한 오케스트레이션 시스템 필요",
+      "클라우드 워커의 네트워크 지연"
+    ]
   },
   "tags": ["distributed-systems", "parallelization", "cloud", "worktrees", "git"]
 }

--- a/src/data/patterns/extended-coherence-work-sessions.json
+++ b/src/data/patterns/extended-coherence-work-sessions.json
@@ -6,27 +6,47 @@
   "status": "rapidly-improving",
   "original_url": "https://www.nibzard.com/silent-revolution",
   "problem": {
-    "en": "Early AI agents suffered from short coherence windows, only maintaining focus and context for a few minutes before performance degraded. This limited utility for complex, multi-stage tasks requiring sustained effort over hours.",
-    "ko": "초기 AI 에이전트는 짧은 일관성 창으로 고통받아 몇 분만 집중과 컨텍스트를 유지한 후 성능이 저하되었습니다. 이로 인해 몇 시간에 걸친 지속적인 노력이 필요한 복잡한 다단계 작업의 활용이 제한되었습니다."
+    "en": "Early AI agents and models often suffered from a short \"coherence window,\" meaning they could only maintain focus and context for a few minutes before their performance degraded significantly (e.g., losing track of instructions, generating irrelevant output). This limited their utility for complex, multi-stage tasks that require sustained effort over hours.",
+    "ko": "초기 AI 에이전트와 모델은 짧은 \"일관성 윈도우\"로 어려움을 겪었습니다. 이는 몇 분만 집중과 컨텍스트를 유지한 후 성능이 크게 저하되는 것을 의미합니다(예: 지시사항 추적 실패, 관련 없는 출력 생성). 이로 인해 수 시간에 걸친 지속적인 노력이 필요한 복잡한 다단계 작업에서의 활용이 제한되었습니다."
   },
   "solution": {
-    "en": "Utilize AI models and agent architectures designed to maintain coherence over extended periods (hours). Leverage newer models with larger context windows, implement state management, and enable agents to work on substantial projects without quality degradation.",
-    "ko": "장시간(시간 단위)에 걸쳐 일관성을 유지하도록 설계된 AI 모델과 에이전트 아키텍처를 활용합니다. 더 큰 컨텍스트 창을 가진 최신 모델을 활용하고, 상태 관리를 구현하며, 에이전트가 품질 저하 없이 상당한 프로젝트에서 작업할 수 있게 합니다."
+    "en": "Utilize AI models and agent architectures that maintain coherence over extended periods (hours rather than minutes). This involves:\n\n- Model Selection: Newer foundation models demonstrate approximately 2x coherence improvement every 7 months.\n- Context Management: Larger context windows alone don't guarantee coherence - combine with auto-compaction, prompt caching, and curated context to mitigate the \"lost in the middle\" effect where models struggle with information in middle positions (Liu et al., 2023).\n- Complementary Patterns: Works synergistically with context auto-compaction, episodic memory, filesystem-based state, and planner-worker separation.\n\nThe goal is enabling agents to work on multi-hour tasks without degradation in output quality or relevance.",
+    "ko": "장시간(분이 아닌 시간 단위)에 걸쳐 일관성을 유지하는 AI 모델과 에이전트 아키텍처를 활용합니다. 이는 다음을 포함합니다:\n\n- 모델 선택: 최신 파운데이션 모델은 약 7개월마다 2배의 일관성 향상을 보입니다.\n- 컨텍스트 관리: 더 큰 컨텍스트 윈도우만으로는 일관성을 보장하지 못합니다. 모델이 중간 위치의 정보에 어려움을 겪는 \"중간에서 길을 잃는\" 효과(Liu et al., 2023)를 완화하기 위해 자동 압축, 프롬프트 캐싱, 큐레이션된 컨텍스트와 결합해야 합니다.\n- 보완 패턴: 컨텍스트 자동 압축, 에피소딕 메모리, 파일시스템 기반 상태, 플래너-워커 분리와 시너지 효과를 냅니다.\n\n목표는 에이전트가 출력 품질이나 관련성의 저하 없이 다시간 작업을 수행할 수 있도록 하는 것입니다."
   },
   "ascii_diagram": "┌─────────────────────────────────┐\n│    Agent Coherence Over Time    │\n├─────────────────────────────────┤\n│                                 │\n│ Early Models:                   │\n│ ████░░░░░░░░░ (5-10 minutes)    │\n│                                 │\n│ Current Models:                 │\n│ █████████████████ (2-4 hours)   │\n│                                 │\n│ Future Trend:                   │\n│ █████████████████████████████   │\n│ (All-day coherence)             │\n│                                 │\n└─────────────────────────────────┘\n\n\"Every 7 months, we double the\n minutes AI can stay coherent\"",
   "mermaid_diagram": "gantt\n    title Agent Coherence Capabilities Over Time\n    dateFormat X\n    axisFormat %s\n    section Early Models\n    Short coherence (minutes) :done, early, 0, 300\n    section Current Models\n    Extended coherence (hours) :active, current, 300, 10800\n    section Future Trend\n    All-day coherence :future, 10800, 86400",
   "code_example": "# Extended coherence enables complex multi-hour tasks\nclass LongRunningAgent:\n    def __init__(self, model):\n        self.model = model  # Model with large context window\n        self.state_manager = StateManager()\n    \n    async def work_session(self, project):\n        # Agent can maintain coherence for hours\n        session_start = time.now()\n        \n        while not project.complete:\n            # Retrieve relevant context\n            context = self.state_manager.get_context()\n            \n            # Execute next step with full awareness\n            result = await self.model.execute(\n                task=project.next_task,\n                context=context\n            )\n            \n            # Update state for continuity\n            self.state_manager.update(result)\n            \n            # Can work for hours without degradation\n            elapsed = time.now() - session_start\n            print(f'Working for {elapsed.hours}h, still coherent')",
   "when_to_use": {
-    "en": ["Complex multi-stage projects", "Tasks requiring sustained reasoning", "Long-form content creation", "Extended debugging sessions"],
-    "ko": ["복잡한 다단계 프로젝트", "지속적인 추론이 필요한 작업", "장문 콘텐츠 생성", "장시간 디버깅 세션"]
+    "en": [
+      "Complex, multi-stage tasks requiring sustained attention (multi-hour coding sessions, long-running research, autonomous workflows)",
+      "Implement supporting patterns first: context auto-compaction, prompt caching, and filesystem-based state",
+      "Monitor for coherence degradation indicators - contradictory statements, goal drift, or repetitive loops after 10-15 conversation turns"
+    ],
+    "ko": [
+      "지속적인 주의가 필요한 복잡한 다단계 작업 (다시간 코딩 세션, 장기 연구, 자율 워크플로우)",
+      "지원 패턴을 먼저 구현: 컨텍스트 자동 압축, 프롬프트 캐싱, 파일시스템 기반 상태",
+      "일관성 저하 지표 모니터링 - 모순된 진술, 목표 이탈, 10-15 대화 턴 후 반복 루프"
+    ]
   },
   "pros": {
-    "en": ["Enables substantial project work", "Maintains quality over time", "Qualitative shift in agent capabilities", "Can match human work session lengths"],
-    "ko": ["상당한 프로젝트 작업 가능", "시간이 지나도 품질 유지", "에이전트 능력의 질적 변화", "인간 작업 세션 길이와 매칭 가능"]
+    "en": [
+      "Enables agents to complete complex, multi-hour tasks previously infeasible",
+      "Foundational capability for autonomous workflows and planner-worker architectures"
+    ],
+    "ko": [
+      "이전에 불가능했던 복잡한 다시간 작업 완료 가능",
+      "자율 워크플로우와 플래너-워커 아키텍처의 기반 역량"
+    ]
   },
   "cons": {
-    "en": ["Higher computational costs for long sessions", "Requires careful state management", "Still improving (not perfect)", "May need architectural support"],
-    "ko": ["긴 세션의 높은 계산 비용", "신중한 상태 관리 필요", "여전히 개선 중 (완벽하지 않음)", "아키텍처 지원 필요할 수 있음"]
+    "en": [
+      "Requires supporting infrastructure (context management, state persistence, memory systems)",
+      "Extended sessions without prompt caching become prohibitively expensive"
+    ],
+    "ko": [
+      "지원 인프라 필요 (컨텍스트 관리, 상태 영속성, 메모리 시스템)",
+      "프롬프트 캐싱 없는 장시간 세션은 비용이 과도하게 높아짐"
+    ]
   },
   "tags": ["coherence", "long-running-tasks", "agent-capability", "complex-projects", "context-window"]
 }

--- a/src/data/patterns/pii-tokenization.json
+++ b/src/data/patterns/pii-tokenization.json
@@ -6,27 +6,63 @@
   "status": "established",
   "original_url": "https://www.anthropic.com/engineering/code-execution-with-mcp",
   "problem": {
-    "en": "AI agents processing workflows involving PII create privacy risks when raw personal data enters model context.",
-    "ko": "PII가 포함된 워크플로우를 처리하는 AI 에이전트가 원시 개인 데이터가 모델 컨텍스트에 들어갈 때 프라이버시 위험을 생성합니다."
+    "en": "AI agents often need to process workflows involving personally identifiable information (PII) such as emails, phone numbers, addresses, or financial data. However, sending raw PII through the model's context creates privacy risks and compliance concerns. Organizations need agents to orchestrate data workflows without exposing sensitive information to the LLM.",
+    "ko": "AI 에이전트는 이메일, 전화번호, 주소, 금융 데이터 등 개인 식별 정보(PII)가 포함된 워크플로우를 처리해야 하는 경우가 많습니다. 그러나 원시 PII를 모델의 컨텍스트를 통해 전송하면 프라이버시 위험과 규정 준수 문제가 발생합니다. 조직은 민감한 정보를 LLM에 노출하지 않으면서 에이전트가 데이터 워크플로우를 오케스트레이션할 수 있어야 합니다."
   },
   "solution": {
-    "en": "Implement an MCP interception layer that tokenizes PII before it reaches the model and untokenizes when making tool calls.",
-    "ko": "PII가 모델에 도달하기 전에 토큰화하고 도구 호출 시 토큰 해제하는 MCP 인터셉션 레이어를 구현합니다."
+    "en": "Implement an interception layer in the Model Context Protocol (MCP) client that automatically tokenizes PII before it reaches the model, and untokenizes it when making subsequent tool calls.\n\n**Flow:**\n\n1. **Interception**: When tools return data, MCP client intercepts responses\n2. **Detection**: Identify PII using pattern matching or classification models\n3. **Tokenization**: Replace real values with placeholders\n   - `john.doe@company.com` → `[EMAIL_1]`\n   - `(555) 123-4567` → `[PHONE_1]`\n   - `123-45-6789` → `[SSN_1]`\n4. **Model reasoning**: Agent works with tokenized placeholders\n5. **Untokenization**: When agent makes tool calls with placeholders, MCP client substitutes real values back",
+    "ko": "MCP(Model Context Protocol) 클라이언트에 PII가 모델에 도달하기 전에 자동으로 토큰화하고, 후속 도구 호출 시 토큰을 해제하는 인터셉션 레이어를 구현합니다.\n\n**흐름:**\n\n1. **인터셉션**: 도구가 데이터를 반환할 때 MCP 클라이언트가 응답을 가로챕니다\n2. **감지**: 패턴 매칭 또는 분류 모델을 사용하여 PII를 식별합니다\n3. **토큰화**: 실제 값을 플레이스홀더로 대체합니다\n   - `john.doe@company.com` → `[EMAIL_1]`\n   - `(555) 123-4567` → `[PHONE_1]`\n   - `123-45-6789` → `[SSN_1]`\n4. **모델 추론**: 에이전트가 토큰화된 플레이스홀더로 작업합니다\n5. **토큰 해제**: 에이전트가 플레이스홀더로 도구를 호출하면 MCP 클라이언트가 실제 값을 대체합니다"
   },
   "ascii_diagram": "┌─────────────┐\n│Tool Response│\n│john@ex.com │\n└──────┬──────┘\n       │ intercept\n┌──────▼──────┐\n│  Tokenize   │\n│ [EMAIL_1]   │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│Model reasons│\n│with tokens  │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│ Untokenize  │\n│john@ex.com │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│   Execute   │\n└─────────────┘",
   "mermaid_diagram": "flowchart LR\n    A[Tool Response] --> B[MCP Client]\n    B --> C{PII Detection}\n    C --> D[Tokenization]\n    D --> E[Model Context]\n    E --> F[Model Reasoning]\n    F --> G[Tool Call with Tokens]\n    G --> H[Untokenization]\n    H --> I[Actual Tool Call]",
   "code_example": "# Tool returns customer data\ncustomer = get_customer(id='C123')\n# Raw: {'email': 'john@example.com', 'phone': '555-1234'}\n\n# MCP client tokenizes before sending to model\n# Context sees: {'email': '[EMAIL_1]', 'phone': '[PHONE_1]'}\n\n# Agent reasons with tokens\n# \"Send welcome email to [EMAIL_1]\"\n\n# MCP client untokenizes for tool execution\nsend_email(\n    to='john@example.com',  # Real value substituted\n    body='Welcome...'\n)",
   "when_to_use": {
-    "en": ["Customer data processing", "Healthcare workflows", "GDPR/HIPAA compliance"],
-    "ko": ["고객 데이터 처리", "의료 워크플로우", "GDPR/HIPAA 준수"]
+    "en": [
+      "Workflows processing customer data, HR records, medical information",
+      "Multi-step automation involving PII",
+      "Compliance-sensitive environments (GDPR, HIPAA, CCPA)",
+      "Agents that coordinate data flows without needing to \"see\" raw PII"
+    ],
+    "ko": [
+      "고객 데이터, HR 기록, 의료 정보를 처리하는 워크플로우",
+      "PII가 포함된 다단계 자동화",
+      "규정 준수가 중요한 환경 (GDPR, HIPAA, CCPA)",
+      "원시 PII를 '보지' 않고 데이터 흐름을 조정하는 에이전트"
+    ]
   },
   "pros": {
-    "en": ["Prevents raw PII in context", "Enables audit trails without PII", "Transparent to agent"],
-    "ko": ["컨텍스트에 원시 PII 방지", "PII 없는 감사 추적 가능", "에이전트에 투명"]
+    "en": [
+      "Prevents raw PII from entering model context",
+      "Agents can orchestrate sensitive workflows without seeing data",
+      "Enables audit trails that don't contain PII",
+      "Reduces compliance risk and regulatory burden",
+      "Transparent to agent reasoning (works with placeholders)"
+    ],
+    "ko": [
+      "원시 PII가 모델 컨텍스트에 진입하는 것을 방지",
+      "에이전트가 데이터를 보지 않고 민감한 워크플로우를 오케스트레이션 가능",
+      "PII가 포함되지 않은 감사 추적 가능",
+      "규정 준수 위험 및 규제 부담 감소",
+      "에이전트 추론에 투명함 (플레이스홀더로 작동)"
+    ]
   },
   "cons": {
-    "en": ["PII detection must be accurate", "Secure token mapping storage needed", "May complicate debugging"],
-    "ko": ["PII 감지가 정확해야 함", "안전한 토큰 매핑 저장 필요", "디버깅 복잡해질 수 있음"]
+    "en": [
+      "Adds complexity to MCP client implementation",
+      "PII detection must be accurate (false positives/negatives)",
+      "Doesn't protect against PII inference (model might deduce sensitive info)",
+      "Requires secure token mapping storage",
+      "May complicate debugging (need to map tokens back for troubleshooting)",
+      "Pattern matching can miss novel PII formats"
+    ],
+    "ko": [
+      "MCP 클라이언트 구현에 복잡성 추가",
+      "PII 감지가 정확해야 함 (거짓 양성/음성)",
+      "PII 추론을 방어하지 못함 (모델이 민감한 정보를 추론할 수 있음)",
+      "안전한 토큰 매핑 저장소 필요",
+      "디버깅이 복잡해질 수 있음 (문제 해결 시 토큰을 역매핑해야 함)",
+      "패턴 매칭이 새로운 PII 형식을 놓칠 수 있음"
+    ]
   },
   "tags": ["privacy", "pii", "security", "mcp", "data-protection"]
 }

--- a/src/data/patterns/plan-then-execute-pattern.json
+++ b/src/data/patterns/plan-then-execute-pattern.json
@@ -6,27 +6,45 @@
   "status": "established",
   "original_url": "https://arxiv.org/abs/2506.08837",
   "problem": {
-    "en": "Agents that plan and execute simultaneously are vulnerable to prompt injection mid-execution.",
-    "ko": "계획과 실행을 동시에 수행하는 에이전트는 실행 중 프롬프트 인젝션에 취약합니다."
+    "en": "When planning and execution are interleaved in one loop, untrusted tool outputs can influence which action is selected next. That makes the control flow itself attackable: a malicious intermediate result can redirect the agent into unsafe tools or unauthorized operations.",
+    "ko": "계획과 실행이 하나의 루프에서 인터리브되면, 신뢰할 수 없는 도구 출력이 다음에 선택되는 행동에 영향을 줄 수 있습니다. 이로 인해 제어 흐름 자체가 공격 가능해지며, 악의적인 중간 결과가 에이전트를 안전하지 않은 도구나 비인가 작업으로 리다이렉트할 수 있습니다."
   },
   "solution": {
-    "en": "Separate planning phase from execution, locking the plan before any untrusted data processing begins.",
-    "ko": "계획 단계를 실행과 분리하고, 신뢰할 수 없는 데이터 처리 시작 전에 계획을 잠급니다."
+    "en": "Split reasoning into two phases:\n\n1. Plan phase - LLM generates a fixed sequence of tool calls before it sees any untrusted data.\n2. Execution phase - Controller runs that exact sequence. Tool outputs may shape parameters, but cannot change which tools run.\n\nThis separates strategic decisions from data-dependent execution. The planner commits to a bounded action graph up front, and the executor enforces that graph deterministically, which preserves flexibility on arguments while protecting control-flow integrity.\n\nPlanning before execution improves task completion rates by 40-70% and reduces hallucinations by ~60% (Parisien et al., 2024).\n\nClaude Code implements this through \"plan mode\" which shifts the agent into planning-only mode, where the agent generates a detailed plan, the human reviews and approves, then the agent follows the approved plan. This can 2-3x success rates for complex tasks. The threshold of what requires planning changes with each model generation as newer models push the boundary of what can be one-shot.",
+    "ko": "추론을 두 단계로 분리합니다:\n\n1. 계획 단계 - LLM이 신뢰할 수 없는 데이터를 보기 전에 고정된 도구 호출 시퀀스를 생성합니다.\n2. 실행 단계 - 컨트롤러가 정확히 해당 시퀀스를 실행합니다. 도구 출력은 매개변수에 영향을 줄 수 있지만, 실행되는 도구를 변경할 수 없습니다.\n\n이를 통해 전략적 결정을 데이터 의존적 실행과 분리합니다. 플래너가 사전에 한정된 행동 그래프를 확정하고, 실행자가 해당 그래프를 결정론적으로 적용하여 인자의 유연성을 유지하면서 제어 흐름 무결성을 보호합니다.\n\n실행 전 계획은 작업 완료율을 40-70% 향상시키고 환각을 약 60% 감소시킵니다(Parisien et al., 2024).\n\nClaude Code는 에이전트를 계획 전용 모드로 전환하는 \"plan mode\"를 통해 이를 구현합니다. 에이전트가 상세 계획을 생성하고, 사람이 검토 및 승인한 후 에이전트가 승인된 계획을 따릅니다. 이를 통해 복잡한 작업의 성공률을 2-3배 높일 수 있습니다. 계획이 필요한 임계값은 각 모델 세대마다 변화하며, 더 새로운 모델은 원샷으로 처리할 수 있는 경계를 확장합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│   Task      │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│   PLAN      │\n│  (locked)   │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│  EXECUTE    │\n│ (no modify) │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│   Result    │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Task] --> B[Planning Phase]\n    B -->|Lock Plan| C[Execution Phase]\n    C --> D[Result]\n    E[Untrusted Data] -->|Cannot modify| B",
   "code_example": "plan = agent.create_plan(task)  # No untrusted data\nplan.lock()  # Freeze the plan\nfor step in plan.steps:\n    result = agent.execute(step, untrusted_data)\n# Plan cannot be modified during execution",
   "when_to_use": {
-    "en": ["Security-sensitive agents", "Multi-step tasks", "External input processing"],
-    "ko": ["보안 민감 에이전트", "다단계 작업", "외부 입력 처리"]
+    "en": [
+      "Email-and-calendar bots, SQL assistants, code-review helpers - any task where the action set is known but parameters vary",
+      "Claude Code plan mode: Shift to planning-only mode for complex tasks, then execute the approved plan",
+      "LangChain Plan-and-Execute: Separate planner and executor agents for step-by-step plan generation and sequential execution"
+    ],
+    "ko": [
+      "이메일-캘린더 봇, SQL 어시스턴트, 코드 리뷰 헬퍼 등 행동 집합은 알려져 있지만 매개변수가 달라지는 작업",
+      "Claude Code plan mode: 복잡한 작업을 위해 계획 전용 모드로 전환 후 승인된 계획을 실행",
+      "LangChain Plan-and-Execute: 단계별 계획 생성과 순차 실행을 위한 별도의 플래너와 실행자 에이전트"
+    ]
   },
   "pros": {
-    "en": ["Prompt injection defense", "Predictable execution", "Auditable"],
-    "ko": ["프롬프트 인젝션 방어", "예측 가능한 실행", "감사 가능"]
+    "en": [
+      "Strong control-flow integrity",
+      "Moderate flexibility"
+    ],
+    "ko": [
+      "강력한 제어 흐름 무결성",
+      "적절한 유연성"
+    ]
   },
   "cons": {
-    "en": ["Reduced flexibility", "Harder dynamic adaptation"],
-    "ko": ["유연성 감소", "동적 적응 어려움"]
+    "en": [
+      "Content of outputs can still be poisoned (e.g., bad email body)"
+    ],
+    "ko": [
+      "출력 내용은 여전히 오염될 수 있음 (예: 잘못된 이메일 본문)"
+    ]
   },
   "tags": ["planning", "control-flow-integrity", "prompt-injection", "security"]
 }

--- a/src/data/patterns/proactive-agent-state-externalization.json
+++ b/src/data/patterns/proactive-agent-state-externalization.json
@@ -6,27 +6,55 @@
   "status": "emerging",
   "original_url": "https://cognition.ai/blog/devin-sonnet-4-5-lessons-and-challenges",
   "problem": {
-    "en": "Models like Sonnet 4.5 proactively write notes to files, but self-generated notes are often incomplete or miss crucial context.",
-    "ko": "Sonnet 4.5 같은 모델이 능동적으로 파일에 노트를 작성하지만, 자체 생성된 노트는 종종 불완전하거나 중요한 맥락을 놓칩니다."
+    "en": "Modern models like Claude Sonnet 4.5 proactively attempt to externalize their state by writing summaries and notes (e.g., CHANGELOG.md, SUMMARY.md) to the file system without explicit prompting. However, self-generated notes are often incomplete or miss crucial context, models may spend more tokens on documentation than actual problem-solving, performance can degrade when agents rely exclusively on their own summaries, knowledge gaps emerge from inadequate self-documentation, and the behavior intensifies near context window limits as a coping mechanism.",
+    "ko": "Claude Sonnet 4.5와 같은 최신 모델은 명시적 지시 없이도 파일 시스템에 요약과 노트(예: CHANGELOG.md, SUMMARY.md)를 작성하여 능동적으로 상태를 외부화하려 합니다. 그러나 자체 생성된 노트는 종종 불완전하거나 중요한 컨텍스트를 놓치고, 모델이 실제 문제 해결보다 문서화에 더 많은 토큰을 소비할 수 있으며, 에이전트가 자체 요약에만 의존하면 성능이 저하될 수 있습니다. 또한 부적절한 자체 문서화로 지식 격차가 발생하고, 컨텍스트 윈도우 한계 근처에서 대응 메커니즘으로 이 행동이 강화됩니다."
   },
   "solution": {
-    "en": "Implement structured approaches to guide and validate the model's natural tendency toward state externalization.",
-    "ko": "모델의 상태 외부화에 대한 자연스러운 경향을 안내하고 검증하는 구조화된 접근 방식을 구현합니다."
+    "en": "Implement structured approaches to leverage and enhance the model's natural tendency toward state externalization:\n\n1. Guided Self-Documentation Framework: Provide templates and schemas for agent-generated notes, define minimum information requirements for state preservation, and establish validation checkpoints for self-generated summaries.\n\n2. Hybrid Memory Architecture: Combine agent self-documentation with external memory management, use agent notes as supplementary (not primary) state storage, implement fallback mechanisms when self-generated context is insufficient, and account for increased summary token generation with shorter context windows.\n\n3. Progressive State Building: Encourage incremental note-taking throughout long sessions, structure documentation to capture decision rationale (not just actions), and include explicit uncertainty markers and knowledge gaps.",
+    "ko": "모델의 상태 외부화에 대한 자연스러운 경향을 활용하고 강화하는 구조화된 접근 방식을 구현합니다:\n\n1. 가이드 자체 문서화 프레임워크: 에이전트 생성 노트를 위한 템플릿과 스키마를 제공하고, 상태 보존을 위한 최소 정보 요구사항을 정의하며, 자체 생성된 요약에 대한 검증 체크포인트를 수립합니다.\n\n2. 하이브리드 메모리 아키텍처: 에이전트 자체 문서화와 외부 메모리 관리를 결합하고, 에이전트 노트를 보조적(주요가 아닌) 상태 저장소로 사용하며, 자체 생성 컨텍스트가 부족할 때 대체 메커니즘을 구현하고, 짧은 컨텍스트 윈도우에서 증가하는 요약 토큰 생성을 고려합니다.\n\n3. 점진적 상태 구축: 장기 세션 전체에 걸쳐 점진적 노트 작성을 장려하고, 행동뿐만 아니라 결정 근거를 포착하도록 문서화를 구조화하며, 명시적 불확실성 표시와 지식 격차를 포함합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│   Agent     │\n│  Working    │\n└──────┬──────┘\n       │ writes\n┌──────▼──────┐\n│  NOTES.md   │\n│ (template)  │\n├─────────────┤\n│ ## Objective│\n│ ## Progress │\n│ ## Gaps     │\n└──────┬──────┘\n       │ validate\n┌──────▼──────┐\n│ Completeness│\n│   Check     │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Agent Working] --> B[Guided Note Template]\n    B --> C[Write Progress Notes]\n    C --> D{Notes Complete?}\n    D -->|No| E[Prompt for Missing Info]\n    E --> C\n    D -->|Yes| F[Continue Work]",
   "code_example": "# Provide template for agent notes\nnote_template = '''\n## Current Objective\n{objective}\n\n## Progress Summary\n- Completed: ...\n- In Progress: ...\n- Next: ...\n\n## Knowledge Gaps\n- Unknown: ...\n- Need Clarification: ...\n'''\n\n# Validate completeness\ndef validate_notes(notes):\n    required = ['Objective', 'Progress', 'Gaps']\n    return all(section in notes for section in required)",
   "when_to_use": {
-    "en": ["Long-running development sessions", "Research and analysis", "Subagent coordination"],
-    "ko": ["장기 개발 세션", "연구 및 분석", "서브에이전트 조정"]
+    "en": [
+      "Long-running development sessions: Multi-hour coding projects requiring state continuity",
+      "Research and analysis: Complex investigations spanning multiple sessions",
+      "Subagent coordination: When main agents need to communicate state to spawned subagents; this behavior may represent a natural pattern for agent-to-agent communication"
+    ],
+    "ko": [
+      "장기 개발 세션: 상태 연속성이 필요한 다시간 코딩 프로젝트",
+      "연구 및 분석: 여러 세션에 걸친 복잡한 조사",
+      "서브에이전트 조정: 메인 에이전트가 생성된 서브에이전트에 상태를 전달해야 할 때; 에이전트 간 통신의 자연스러운 패턴"
+    ]
   },
   "pros": {
-    "en": ["Leverages natural model behavior", "Better session continuity", "Creates audit trails"],
-    "ko": ["자연스러운 모델 동작 활용", "더 나은 세션 연속성", "감사 추적 생성"]
+    "en": [
+      "Leverages natural model behavior",
+      "Enables better session continuity",
+      "Facilitates subagent communication",
+      "Creates audit trails"
+    ],
+    "ko": [
+      "자연스러운 모델 동작 활용",
+      "더 나은 세션 연속성 지원",
+      "서브에이전트 통신 촉진",
+      "감사 추적 생성"
+    ]
   },
   "cons": {
-    "en": ["May consume tokens on documentation", "Requires validation overhead"],
-    "ko": ["문서화에 토큰 소비 가능", "검증 오버헤드 필요"]
+    "en": [
+      "May consume tokens on documentation over progress",
+      "Requires validation overhead",
+      "Risk of incomplete self-assessment",
+      "Potential for \"documentation theater\""
+    ],
+    "ko": [
+      "진행보다 문서화에 토큰 소비 가능",
+      "검증 오버헤드 필요",
+      "불완전한 자기 평가 위험",
+      "\"문서화 극장\" 가능성"
+    ]
   },
   "tags": ["state-externalization", "memory-management", "self-documentation", "note-taking"]
 }

--- a/src/data/patterns/seamless-background-to-foreground-handoff.json
+++ b/src/data/patterns/seamless-background-to-foreground-handoff.json
@@ -6,27 +6,51 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=BGgsoIgbT_Y",
   "problem": {
-    "en": "Background agents achieve 90% correctness but the remaining 10% requires human finesse; clunky handoffs negate automation benefits.",
-    "ko": "백그라운드 에이전트가 90% 정확도를 달성하지만 나머지 10%는 인간의 손길이 필요합니다. 어색한 핸드오프가 자동화 이점을 무효화합니다."
+    "en": "While background agents can handle long-running, complex tasks autonomously, they might not achieve 100% correctness or perfectly match the user's nuanced intent. If an agent completes 90% of a task in the background but the remaining 10% requires human finesse, a clunky handoff process can negate the benefits of automation.",
+    "ko": "백그라운드 에이전트가 장기 실행되는 복잡한 작업을 자율적으로 처리할 수 있지만, 100% 정확성을 달성하거나 사용자의 세밀한 의도를 완벽하게 반영하지 못할 수 있습니다. 에이전트가 백그라운드에서 작업의 90%를 완료하더라도 나머지 10%에 인간의 세밀한 조정이 필요한 경우, 어색한 핸드오프 프로세스가 자동화의 이점을 무효화할 수 있습니다."
   },
   "solution": {
-    "en": "Design seamless transitions from background agent work to foreground human control, preserving context and enabling easy refinement.",
-    "ko": "백그라운드 에이전트 작업에서 포그라운드 인간 제어로의 원활한 전환을 설계하여 컨텍스트를 보존하고 쉬운 개선을 가능하게 합니다."
+    "en": "Design the agent system to allow for a seamless transition from background (autonomous) agent work to foreground (human-in-the-loop or direct human control) work. This means:\n\n1. The background agent performs its task (e.g., generating a PR).\n2. The user reviews the agent's work.\n3. If the work is not entirely satisfactory (e.g., 90% correct), the user can easily \"take control\" or bring the task into their active foreground environment.\n4. The user can then utilize the same (or related) interactive AI tools and direct editing capabilities used in the foreground to refine, correct, or complete the remaining parts of the task.\n5. The context from the background agent's work should ideally be available to inform the foreground interaction.\n\n**Core mechanisms for seamless handoff:**\n\n- **Context preservation**: Background agents generate distilled summaries and artifacts (PRs, branches, decision logs) rather than transferring full conversation history, achieving 10:1 to 100:1 context compression.\n- **Real-time progress visibility**: WebSocket streaming of agent progress enables users to identify optimal handoff moments and maintain trust during autonomous execution.\n- **Artifact-based coordination**: Git-based workflows with branch-per-task and draft PRs provide durable handoff points that survive process boundaries.\n- **Tool parity**: Background agents use the same tools as developers (IDE terminals, codebase annotations), ensuring workspace-native execution and eliminating context translation.",
+    "ko": "백그라운드(자율) 에이전트 작업에서 포그라운드(인간 참여 또는 직접 인간 제어) 작업으로의 원활한 전환을 허용하도록 에이전트 시스템을 설계합니다. 이는 다음을 의미합니다:\n\n1. 백그라운드 에이전트가 작업을 수행합니다 (예: PR 생성).\n2. 사용자가 에이전트의 작업을 검토합니다.\n3. 작업이 완전히 만족스럽지 않은 경우 (예: 90% 정확), 사용자가 쉽게 '제어권을 가져오거나' 작업을 활성 포그라운드 환경으로 가져올 수 있습니다.\n4. 사용자가 포그라운드에서 사용하는 동일한(또는 관련된) 대화형 AI 도구와 직접 편집 기능을 활용하여 작업의 나머지 부분을 개선, 수정 또는 완료할 수 있습니다.\n5. 백그라운드 에이전트 작업의 컨텍스트가 이상적으로 포그라운드 상호작용에 활용 가능해야 합니다.\n\n**원활한 핸드오프를 위한 핵심 메커니즘:**\n\n- **컨텍스트 보존**: 백그라운드 에이전트가 전체 대화 이력 대신 요약된 산출물(PR, 브랜치, 결정 로그)을 생성하여 10:1~100:1 컨텍스트 압축을 달성합니다.\n- **실시간 진행 상황 가시성**: WebSocket 스트리밍으로 에이전트 진행 상황을 확인하여 최적의 핸드오프 시점을 식별하고 자율 실행 중 신뢰를 유지합니다.\n- **산출물 기반 조정**: 작업별 브랜치와 드래프트 PR을 활용한 Git 기반 워크플로우가 프로세스 경계를 넘어 지속되는 핸드오프 포인트를 제공합니다.\n- **도구 동등성**: 백그라운드 에이전트가 개발자와 동일한 도구(IDE 터미널, 코드베이스 어노테이션)를 사용하여 워크스페이스 네이티브 실행을 보장하고 컨텍스트 변환을 제거합니다."
   },
   "ascii_diagram": "┌─────────────────┐\n│ Background Agent│\n│   Works on X    │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│  Agent PR: 90%  │\n│    Correct      │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ User Reviews    │\n│ Takes Control   │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│Use Foreground   │\n│Tools to Refine  │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│   Finalized PR  │\n└─────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[User: Refactor X in background] --> B[Background Agent Works]\n    B --> C[Agent Proposes PR]\n    C --> D{User Reviews}\n    D -->|90% Correct| E[User Takes Over]\n    E --> F[Use Foreground Tools to Refine]\n    F --> G[Finalized PR]\n    D -->|100% Correct| G",
   "code_example": "# Background agent produces PR\npr = background_agent.create_pr(task)\n\n# User reviews and takes control\nif pr.needs_refinement:\n    # Seamlessly switch to interactive mode\n    # Context from background work is available\n    foreground_session = open_with_context(pr.context)\n    foreground_agent.refine(pr, foreground_session)",
   "when_to_use": {
-    "en": ["Complex code generation", "PR workflows", "Near-complete automation"],
-    "ko": ["복잡한 코드 생성", "PR 워크플로우", "거의 완전한 자동화"]
+    "en": [
+      "When humans and agents share ownership of work across handoffs",
+      "Start with clear interaction contracts for approvals, overrides, and escalation",
+      "Capture user feedback in structured form so prompts and workflows can improve"
+    ],
+    "ko": [
+      "인간과 에이전트가 핸드오프를 통해 작업 소유권을 공유하는 경우",
+      "승인, 오버라이드, 에스컬레이션에 대한 명확한 상호작용 계약으로 시작",
+      "프롬프트와 워크플로우 개선을 위해 구조화된 형태로 사용자 피드백 수집"
+    ]
   },
   "pros": {
-    "en": ["Best of both worlds", "No lost context", "Efficient human time"],
-    "ko": ["두 세계의 장점", "컨텍스트 손실 없음", "효율적인 인간 시간"]
+    "en": [
+      "Creates clearer human-agent handoffs and better operational trust",
+      "Enables 90% automation while preserving 10% human expertise",
+      "Better than pure autonomy when tasks require nuanced judgment"
+    ],
+    "ko": [
+      "더 명확한 인간-에이전트 핸드오프와 더 나은 운영 신뢰 생성",
+      "10% 인간 전문성을 보존하면서 90% 자동화 가능",
+      "세밀한 판단이 필요한 작업에서 순수 자율성보다 우수"
+    ]
   },
   "cons": {
-    "en": ["Context transfer complexity", "UI design challenges"],
-    "ko": ["컨텍스트 전송 복잡성", "UI 설계 도전"]
+    "en": [
+      "Needs explicit process design and coordination",
+      "Context preservation at handoff boundaries adds implementation complexity",
+      "Requires real-time progress visibility infrastructure"
+    ],
+    "ko": [
+      "명시적인 프로세스 설계와 조정 필요",
+      "핸드오프 경계에서의 컨텍스트 보존이 구현 복잡성을 추가",
+      "실시간 진행 상황 가시성 인프라 필요"
+    ]
   },
-  "tags": ["background-agent", "human-in-the-loop", "task-handoff", "workflow"]
+  "tags": ["background-agent", "human-in-the-loop", "task-handoff", "interactive-refinement", "agent-collaboration", "developer-workflow"]
 }

--- a/src/data/patterns/spectrum-of-control-blended-initiative.json
+++ b/src/data/patterns/spectrum-of-control-blended-initiative.json
@@ -6,27 +6,57 @@
   "status": "validated-in-production",
   "original_url": "https://www.youtube.com/watch?v=BGgsoIgbT_Y",
   "problem": {
-    "en": "One-size-fits-all agent autonomy doesn't cater to diverse user needs or varying task complexity.",
-    "ko": "획일적인 에이전트 자율성은 다양한 사용자 요구나 다양한 작업 복잡성을 충족시키지 못합니다."
+    "en": "AI agents for tasks like coding can offer various levels of assistance, from simple completions to complex, multi-step operations. A one-size-fits-all approach to agent autonomy doesn't cater to the diverse needs of users or the varying complexity of tasks. Users need to fluidly shift between direct control and delegating tasks to the agent.",
+    "ko": "코딩과 같은 작업을 위한 AI 에이전트는 간단한 완성부터 복잡한 다단계 작업까지 다양한 수준의 지원을 제공할 수 있습니다. 에이전트 자율성에 대한 획일적인 접근 방식은 사용자의 다양한 요구나 작업의 다양한 복잡성을 충족시키지 못합니다. 사용자는 직접 제어와 에이전트에게 작업을 위임하는 것 사이를 유동적으로 전환할 수 있어야 합니다."
   },
   "solution": {
-    "en": "Design interaction to support a spectrum of control levels, from simple completions to fully autonomous operations.",
-    "ko": "간단한 완성부터 완전 자율 작업까지 다양한 제어 수준을 지원하도록 상호작용을 설계합니다."
+    "en": "Design the human-agent interaction to support a spectrum of control, allowing users to choose the level of agent autonomy appropriate for the current task or their familiarity with the codebase. This involves providing multiple modes or features for interaction:\n\n- **Low Autonomy (High Human Control):** Simple, inline assistance like tab-completion for code, where the human is primarily driving and the AI augments their input.\n- **Medium Autonomy:** Agent assistance for more contained tasks, like editing a selected region of code or an entire file based on a specific instruction (e.g., \"Command K\" functionality). The human defines the scope and the high-level goal.\n- **High Autonomy:** Agent takes on larger, multi-file tasks or complex refactorings, potentially involving multiple steps, with less direct human guidance on each step (e.g., an \"Agent\" feature).\n- **Very High Autonomy (Asynchronous):** Background agents that can take on entire complex tasks like implementing a feature or fixing a set of bugs and creating a pull request, operating largely independently.\n\nUsers can seamlessly switch between these modes depending on their needs, allowing for a \"blended initiative\" where both human and AI contribute effectively.",
+    "ko": "사용자가 현재 작업이나 코드베이스 숙련도에 적합한 에이전트 자율성 수준을 선택할 수 있도록 제어 스펙트럼을 지원하는 인간-에이전트 상호작용을 설계합니다. 여러 상호작용 모드 또는 기능을 제공합니다:\n\n- **낮은 자율성 (높은 인간 제어):** 탭 완성과 같은 간단한 인라인 지원으로, 인간이 주도하고 AI가 입력을 보강합니다.\n- **중간 자율성:** 특정 지시에 따라 선택된 코드 영역이나 전체 파일을 편집하는 등 제한된 작업에 대한 에이전트 지원입니다 (예: \"Command K\" 기능). 인간이 범위와 상위 목표를 정의합니다.\n- **높은 자율성:** 에이전트가 더 큰 다중 파일 작업이나 복잡한 리팩토링을 수행하며, 각 단계에 대한 직접적인 인간 가이드가 적습니다 (예: \"Agent\" 기능).\n- **매우 높은 자율성 (비동기):** 기능 구현이나 버그 수정, PR 생성과 같은 전체 복잡한 작업을 대부분 독립적으로 수행하는 백그라운드 에이전트입니다.\n\n사용자는 필요에 따라 이러한 모드 간에 원활하게 전환할 수 있으며, 인간과 AI 모두가 효과적으로 기여하는 '혼합 주도권'이 가능합니다."
   },
   "ascii_diagram": "┌─────────────────────────────────┐\n│        Control Spectrum         │\n├─────────────────────────────────┤\n│ Tab     Cmd+K   Agent   BG Agent│\n│ Compl   Edit    Multi   Auto    │\n│   │       │       │       │     │\n│   ▼       ▼       ▼       ▼     │\n│ Human ◄──────────────────► AI   │\n│ Control                  Control│\n└─────────────────────────────────┘",
   "mermaid_diagram": "flowchart LR\n    subgraph Human Control\n        A[Tab Completion]\n    end\n    subgraph Shared Control\n        B[Command K - Edit Region]\n    end\n    subgraph Agent Control\n        C[Agent - Multi-File Edits]\n    end\n    subgraph Autonomous\n        D[Background Agent - PRs]\n    end\n    A --> B --> C --> D",
   "code_example": "class InteractionModes:\n    TAB_COMPLETE = 'low_autonomy'    # Human drives\n    COMMAND_K = 'medium_autonomy'    # Human defines scope\n    AGENT = 'high_autonomy'          # Agent multi-step\n    BACKGROUND = 'full_autonomy'     # Agent async, entire PRs\n\n# User can switch modes fluidly\nif task.complexity == 'simple':\n    use_mode(InteractionModes.TAB_COMPLETE)\nelse:\n    use_mode(InteractionModes.AGENT)",
   "when_to_use": {
-    "en": ["IDE integrations", "Coding assistants", "Varied task complexity"],
-    "ko": ["IDE 통합", "코딩 어시스턴트", "다양한 작업 복잡성"]
+    "en": [
+      "When humans and agents share ownership of work across handoffs",
+      "Start with clear interaction contracts for approvals, overrides, and escalation",
+      "Capture user feedback in structured form so prompts and workflows can improve",
+      "Implement mode-switching controls (keyboard shortcuts, UI toggles) for explicit autonomy level selection",
+      "Pair with human-in-the-loop approval at higher autonomy levels for high-risk operations"
+    ],
+    "ko": [
+      "인간과 에이전트가 핸드오프를 통해 작업 소유권을 공유하는 경우",
+      "승인, 오버라이드, 에스컬레이션에 대한 명확한 상호작용 계약으로 시작",
+      "프롬프트와 워크플로우 개선을 위해 구조화된 형태로 사용자 피드백 수집",
+      "명시적 자율성 수준 선택을 위한 모드 전환 컨트롤 구현 (키보드 단축키, UI 토글)",
+      "고위험 작업에서 높은 자율성 수준에 인간 승인 루프 결합"
+    ]
   },
   "pros": {
-    "en": ["User flexibility", "Appropriate control for each task", "Gradual trust building"],
-    "ko": ["사용자 유연성", "각 작업에 적합한 제어", "점진적 신뢰 구축"]
+    "en": [
+      "Creates clearer human-agent handoffs",
+      "Builds trust through progressive autonomy",
+      "Enables error containment at lower levels",
+      "Allows context-appropriate control selection"
+    ],
+    "ko": [
+      "더 명확한 인간-에이전트 핸드오프 생성",
+      "점진적 자율성을 통한 신뢰 구축",
+      "낮은 수준에서의 오류 억제 가능",
+      "컨텍스트에 적합한 제어 선택 가능"
+    ]
   },
   "cons": {
-    "en": ["Mode switching complexity", "UI/UX design challenges"],
-    "ko": ["모드 전환 복잡성", "UI/UX 설계 도전"]
+    "en": [
+      "Multiple modes can confuse users if not clearly presented",
+      "Requires building/maintaining several interaction paths",
+      "Users may struggle to choose appropriate autonomy level"
+    ],
+    "ko": [
+      "명확하게 제시되지 않으면 여러 모드가 사용자를 혼란스럽게 할 수 있음",
+      "여러 상호작용 경로를 구축하고 유지해야 함",
+      "사용자가 적절한 자율성 수준을 선택하기 어려울 수 있음"
+    ]
   },
-  "tags": ["human-agent-collaboration", "autonomy-spectrum", "interactive-control"]
+  "tags": ["human-agent-collaboration", "autonomy-spectrum", "interactive-control", "task-delegation", "code-editing", "ide-integration"]
 }

--- a/src/data/patterns/virtual-machine-operator-agent.json
+++ b/src/data/patterns/virtual-machine-operator-agent.json
@@ -6,27 +6,47 @@
   "status": "established",
   "original_url": "https://www.nibzard.com/silent-revolution",
   "problem": {
-    "en": "AI agents need to perform complex tasks beyond simple code generation. They require ability to interact with full computer environment: execute code, manage resources, install software, operate applications.",
-    "ko": "AI 에이전트는 단순한 코드 생성을 넘어 복잡한 작업을 수행해야 합니다. 전체 컴퓨터 환경과 상호작용: 코드 실행, 리소스 관리, 소프트웨어 설치, 애플리케이션 운영 능력이 필요합니다."
+    "en": "AI agents need to perform complex tasks beyond simple code generation or text manipulation. They require the ability to interact with a full computer environment to execute code, manage system resources, install software, and operate various applications.",
+    "ko": "AI 에이전트는 단순한 코드 생성이나 텍스트 조작을 넘어 복잡한 작업을 수행해야 합니다. 코드 실행, 시스템 리소스 관리, 소프트웨어 설치, 다양한 애플리케이션 운영을 위해 전체 컴퓨터 환경과 상호작용하는 능력이 필요합니다."
   },
   "solution": {
-    "en": "Equip agent with access to a dedicated virtual machine. Agent is trained to operate within the VM: execute arbitrary code, install packages, read/write files, use CLI tools and applications.",
-    "ko": "에이전트에게 전용 가상 머신 접근 권한 부여. 에이전트가 VM 내에서 작동하도록 훈련: 임의 코드 실행, 패키지 설치, 파일 읽기/쓰기, CLI 도구 및 애플리케이션 사용."
+    "en": "Equip the AI agent with access to a dedicated virtual machine (VM) environment. The agent is trained or designed to understand how to operate within this VM, treating it as its direct workspace. This allows the agent to:\n\n- Execute arbitrary code and scripts.\n- Install and manage software packages.\n- Read from and write to the file system.\n- Utilize other command-line tools and applications available within the VM.\n\nThis pattern transforms the agent from a specialized tool into a more general-purpose digital operator.\n\nCommon implementation approaches include:\n\n- **Full virtual machines** (EC2, GCP) - Maximum isolation, higher overhead\n- **MicroVMs** (Firecracker, Modal, E2B) - Balanced isolation with fast startup\n- **Container isolation** (Docker, Kubernetes) - Faster startup, shared kernel risk\n- **Tool-mediated execution** - Minimal overhead, capability-scoped",
+    "ko": "AI 에이전트에게 전용 가상 머신(VM) 환경에 대한 접근 권한을 부여합니다. 에이전트는 이 VM 내에서 작동하는 방법을 이해하도록 훈련되거나 설계되어, VM을 직접 작업 공간으로 취급합니다. 이를 통해 에이전트는:\n\n- 임의의 코드와 스크립트를 실행합니다.\n- 소프트웨어 패키지를 설치하고 관리합니다.\n- 파일 시스템에서 읽기 및 쓰기를 수행합니다.\n- VM 내에서 사용 가능한 다른 커맨드라인 도구와 애플리케이션을 활용합니다.\n\n이 패턴은 에이전트를 전문화된 도구에서 보다 범용적인 디지털 운영자로 변환합니다.\n\n일반적인 구현 접근 방식:\n\n- **풀 가상 머신** (EC2, GCP) - 최대 격리, 높은 오버헤드\n- **마이크로VM** (Firecracker, Modal, E2B) - 빠른 시작과 균형 잡힌 격리\n- **컨테이너 격리** (Docker, Kubernetes) - 빠른 시작, 공유 커널 위험\n- **도구 매개 실행** - 최소 오버헤드, 기능 범위 제한"
   },
   "ascii_diagram": "┌─────────────────┐\n│     User        │\n│ Complex Task    │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│     Agent       │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ Virtual Machine │\n├─────────────────┤\n│ • Execute Code  │\n│ • Install Pkgs  │\n│ • File System   │\n│ • CLI Tools     │\n│ • Applications  │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│    Results      │\n└─────────────────┘",
   "mermaid_diagram": "sequenceDiagram\n    participant User\n    participant Agent\n    participant VM as Virtual Machine\n\n    User->>Agent: Complex Task Request\n    Agent->>VM: Execute Code/Scripts\n    Agent->>VM: Install Packages\n    Agent->>VM: File System Operations\n    Agent->>VM: Use CLI Tools/Apps\n    VM-->>Agent: Execution Results\n    Agent->>Agent: Process & Analyze\n    Agent-->>User: Task Completion Report",
   "code_example": "class VMOperatorAgent:\n    def __init__(self, vm_connection):\n        self.vm = vm_connection\n    \n    async def execute_task(self, task):\n        # Agent has full VM access\n        await self.vm.run('pip install pandas')\n        await self.vm.write_file('script.py', code)\n        result = await self.vm.run('python script.py')\n        \n        # Can use any installed application\n        await self.vm.run('docker build -t myapp .')\n        await self.vm.run('kubectl apply -f deploy.yaml')\n        \n        return self.analyze_results(result)",
   "when_to_use": {
-    "en": ["Complex multi-tool tasks", "System administration automation", "Development environment operations"],
-    "ko": ["복잡한 다중 도구 작업", "시스템 관리 자동화", "개발 환경 운영"]
+    "en": [
+      "When agent success depends on reliable tool invocation and environment setup",
+      "Start with a narrow tool surface and explicit parameter validation",
+      "Add observability around tool latency, failures, and fallback paths",
+      "Implement automatic cleanup via idle timeouts and hard execution limits",
+      "Ensure state isolation: fresh filesystem per session, no shared network namespaces"
+    ],
+    "ko": [
+      "에이전트 성공이 안정적인 도구 호출과 환경 설정에 의존하는 경우",
+      "좁은 도구 표면과 명시적 매개변수 검증으로 시작",
+      "도구 지연, 실패, 대체 경로에 대한 관찰 가능성 추가",
+      "유휴 타임아웃과 하드 실행 제한을 통한 자동 정리 구현",
+      "상태 격리 보장: 세션당 새로운 파일 시스템, 공유 네트워크 네임스페이스 없음"
+    ]
   },
   "pros": {
-    "en": ["Full computer capabilities", "Can use any application", "General-purpose operator"],
-    "ko": ["전체 컴퓨터 기능", "모든 애플리케이션 사용 가능", "범용 운영자"]
+    "en": [
+      "Improves execution success and lowers tool-call failure rates"
+    ],
+    "ko": [
+      "실행 성공률 향상 및 도구 호출 실패율 감소"
+    ]
   },
   "cons": {
-    "en": ["Security risks with full access", "VM overhead", "Requires careful sandboxing"],
-    "ko": ["전체 접근의 보안 위험", "VM 오버헤드", "신중한 샌드박싱 필요"]
+    "en": [
+      "Introduces integration coupling, environment-specific upkeep, and cold-start latency (1-120s depending on isolation level)"
+    ],
+    "ko": [
+      "통합 결합, 환경별 유지보수, 콜드 스타트 지연(격리 수준에 따라 1-120초) 발생"
+    ]
   },
   "tags": ["computer-operation", "virtual-machine", "execution-environment", "agent-capability"]
 }


### PR DESCRIPTION
## Summary
이슈 #49의 Batch 6 - 변경 규모 51-60위 10개 패턴 업데이트.

## 업데이트된 패턴
- pii-tokenization
- compounding-engineering-pattern
- virtual-machine-operator-agent
- spectrum-of-control-blended-initiative
- seamless-background-to-foreground-handoff
- proactive-agent-state-externalization
- plan-then-execute-pattern
- extended-coherence-work-sessions
- distributed-execution-cloud-workers
- context-minimization-pattern

## Test plan
- [x] \`npm test\` 로컬 통과
- [x] JSON 유효성 검증

Part of #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)