### PR TITLE
feat: Update 10 patterns from upstream (batch 7)

### DIFF
--- a/src/data/patterns/agentic-search-over-vector-embeddings.json
+++ b/src/data/patterns/agentic-search-over-vector-embeddings.json
@@ -6,27 +6,27 @@
   "status": "best-practice",
   "original_url": "https://every.to/podcast/transcript-how-to-use-claude-code-like-the-people-who-built-it",
   "problem": {
-    "en": "Vector embeddings for code search require continuous re-indexing, handling local changes, additional security surface area, and infrastructure overhead. Traditional RAG adds complexity that may not be necessary.",
-    "ko": "코드 검색을 위한 벡터 임베딩은 지속적인 재인덱싱, 로컬 변경 처리, 추가 보안 표면, 인프라 오버헤드가 필요합니다. 전통적인 RAG는 필요하지 않을 수 있는 복잡성을 추가합니다."
+    "en": "Vector embeddings for code search require:\n\n- Continuous re-indexing as code changes\n- Handling local uncommitted changes\n- Additional security surface area for enterprise deployments\n- Infrastructure overhead (embedding models, vector databases)\n- Stale indices when developers work on multiple branches\n\nTraditional RAG approaches add complexity that may not be necessary with modern capable LLMs.",
+    "ko": "코드 검색을 위한 벡터 임베딩에는 다음이 필요합니다:\n\n- 코드 변경 시 지속적인 재인덱싱\n- 로컬 미커밋 변경 사항 처리\n- 엔터프라이즈 배포를 위한 추가 보안 표면\n- 인프라 오버헤드(임베딩 모델, 벡터 데이터베이스)\n- 개발자가 여러 브랜치에서 작업할 때 오래된 인덱스\n\n전통적인 RAG 접근 방식은 현대의 고성능 LLM에는 필요하지 않을 수 있는 복잡성을 추가합니다."
   },
   "solution": {
-    "en": "Replace vector search with agentic search using bash, grep, file traversal. Modern LLMs are skilled at using search tools iteratively to achieve comparable accuracy without maintenance burden.",
-    "ko": "벡터 검색을 bash, grep, 파일 탐색을 사용한 에이전틱 검색으로 대체합니다. 현대 LLM은 유지 관리 부담 없이 비슷한 정확도를 달성하기 위해 검색 도구를 반복적으로 사용하는 데 능숙합니다."
+    "en": "Replace vector search with **agentic search** using bash, grep, file traversal, and other command-line tools. Modern LLMs are skilled enough at using search tools iteratively to achieve comparable accuracy without the maintenance burden of vector indices.\n\n**Key approach:**\n\n1. **Tool-based search**: Provide grep, ripgrep, find, ls, and other search utilities\n2. **Iterative refinement**: Let the agent search multiple times, narrowing results\n3. **No pre-indexing**: Search happens on-demand against current file state\n4. **Optional MCP integration**: If teams want semantic search, expose it via MCP tool\n\n```pseudo\n# Instead of:\nvector_db.index(codebase)  # requires continuous updates\nresults = vector_db.query(embedding(query))\n\n# Use:\nagent.call_tool(\"grep\", pattern=\"function.*authenticate\")\nagent.call_tool(\"find\", pattern=\"**/auth/*.ts\")\nagent.refine_search_based_on_results()\n```",
+    "ko": "벡터 검색을 bash, grep, 파일 탐색 및 기타 커맨드라인 도구를 사용한 **에이전틱 검색**으로 대체합니다. 현대 LLM은 벡터 인덱스의 유지 관리 부담 없이 비슷한 정확도를 달성할 수 있을 만큼 검색 도구를 반복적으로 사용하는 데 능숙합니다.\n\n**핵심 접근 방식:**\n\n1. **도구 기반 검색**: grep, ripgrep, find, ls 및 기타 검색 유틸리티 제공\n2. **반복적 정제**: 에이전트가 여러 번 검색하면서 결과를 좁혀감\n3. **사전 인덱싱 불필요**: 현재 파일 상태에 대해 온디맨드 검색\n4. **선택적 MCP 통합**: 시맨틱 검색이 필요하면 MCP 도구를 통해 노출"
   },
   "ascii_diagram": "TRADITIONAL RAG:\nvector_db.index(codebase) → continuous updates\nresults = vector_db.query(embedding)\n→ Maintenance overhead\n\nAGENTIC SEARCH:\nagent.call_tool('grep', pattern)\nagent.call_tool('find', pattern)\nagent.refine_search_based_on_results()\n→ No pre-indexing needed",
   "mermaid_diagram": "flowchart TD\n    A[Search Query] --> B{Approach}\n    B -->|Traditional| C[Vector DB Index]\n    C --> D[Continuous Re-indexing]\n    D --> E[Query Embeddings]\n    B -->|Agentic| F[grep/ripgrep/find]\n    F --> G[Iterative Refinement]\n    G --> H[Current File State]\n    H --> I[Results]",
   "code_example": "# Instead of vector search:\n# vector_db.index(codebase)  # requires continuous updates\n# results = vector_db.query(embedding(query))\n\n# Use agentic search:\nagent.call_tool('grep', pattern='function.*authenticate')\nagent.call_tool('find', pattern='**/auth/*.ts')\nagent.refine_search_based_on_results()\n\n# Benefits: Always searches current state, no stale results",
   "when_to_use": {
-    "en": ["Frequently changing codebases", "Security-sensitive deployments", "Local development", "No vector infrastructure"],
-    "ko": ["자주 변경되는 코드베이스", "보안에 민감한 배포", "로컬 개발", "벡터 인프라 없음"]
+    "en": ["Code bases with frequent changes", "Teams without dedicated vector infrastructure", "Security-sensitive deployments (fewer external dependencies)", "Local development where files change constantly", "Multi-branch workflows"],
+    "ko": ["자주 변경되는 코드베이스", "전용 벡터 인프라가 없는 팀", "보안에 민감한 배포(외부 의존성 최소화)", "파일이 끊임없이 변경되는 로컬 개발", "멀티 브랜치 워크플로우"]
   },
   "pros": {
-    "en": ["No indexing to maintain", "Always current state", "Simpler security model", "No embedding costs"],
-    "ko": ["유지할 인덱싱 없음", "항상 현재 상태", "더 간단한 보안 모델", "임베딩 비용 없음"]
+    "en": ["No indexing infrastructure to maintain", "Always searches current state (no stale results)", "Works with local uncommitted changes", "Simpler security model", "Faster setup for new repositories", "No embedding model costs"],
+    "ko": ["유지할 인덱싱 인프라 없음", "항상 현재 상태 검색(오래된 결과 없음)", "로컬 미커밋 변경 사항과 호환", "더 간단한 보안 모델", "새 저장소에 대한 빠른 설정", "임베딩 모델 비용 없음"]
   },
   "cons": {
-    "en": ["Multiple iterations needed", "Slower on very large codebases", "Less semantic understanding"],
-    "ko": ["여러 번 반복 필요", "매우 큰 코드베이스에서 느림", "의미적 이해 부족"]
+    "en": ["May require multiple search iterations (more tokens)", "Slower on very large codebases (millions of files)", "Less semantic understanding (e.g., \"authentication\" vs \"login\")", "Requires capable models (Sonnet 4+) for good results", "Higher latency for complex queries"],
+    "ko": ["여러 검색 반복 필요(토큰 증가)", "매우 큰 코드베이스(수백만 파일)에서 느림", "시맨틱 이해 부족(예: \"authentication\" vs \"login\")", "좋은 결과를 위해 고성능 모델(Sonnet 4+) 필요", "복잡한 쿼리에 대한 높은 지연 시간"]
   },
   "tags": ["search", "vector-embeddings", "bash", "grep", "RAG", "agentic-RAG"]
 }

--- a/src/data/patterns/ai-accelerated-learning-and-skill-development.json
+++ b/src/data/patterns/ai-accelerated-learning-and-skill-development.json
@@ -6,27 +6,57 @@
   "status": "validated-in-production",
   "original_url": "https://www.youtube.com/watch?v=BGgsoIgbT_Y",
   "problem": {
-    "en": "Developing strong software engineering skills, including 'taste' for clean code, traditionally requires extensive experience and mentorship. This is a slow process, especially for junior developers who learn through trial-and-error over years.",
-    "ko": "깨끗한 코드에 대한 '취향'을 포함한 강력한 소프트웨어 엔지니어링 기술을 개발하려면 전통적으로 광범위한 경험과 멘토링이 필요합니다. 이는 특히 수년에 걸쳐 시행착오를 통해 배우는 주니어 개발자에게 느린 과정입니다."
+    "en": "Developing strong software engineering skills, including \"taste\" for clean and effective code, traditionally requires extensive experience, trial-and-error, and mentorship, which can be a slow process, especially for junior developers.",
+    "ko": "깨끗하고 효과적인 코드에 대한 '취향'을 포함한 강력한 소프트웨어 엔지니어링 스킬을 개발하려면 전통적으로 광범위한 경험, 시행착오, 멘토링이 필요하며, 이는 특히 주니어 개발자에게 느린 과정입니다."
   },
   "solution": {
-    "en": "Utilize AI agents as interactive learning tools that accelerate skill acquisition. Developers iterate faster, learn from mistakes efficiently with AI explanations, observe best practices in AI-generated code, get on-demand explanations, and experiment without fear.",
-    "ko": "AI 에이전트를 스킬 습득을 가속화하는 대화형 학습 도구로 활용합니다. 개발자는 더 빠르게 반복하고, AI 설명으로 실수에서 효율적으로 배우고, AI 생성 코드에서 모범 사례를 관찰하고, 주문형 설명을 받고, 두려움 없이 실험합니다."
+    "en": "Utilize AI agents as interactive learning tools that accelerate a developer's skill acquisition and \"taste\" development. By using AI coding assistants, developers can:\n\n1. **Iterate Faster:** Quickly try out different approaches and see immediate results or feedback (e.g., compiler errors, test failures, AI-generated alternatives).\n2. **Learn from Mistakes Efficiently:** The AI can help identify and explain errors, allowing developers to understand why something failed more quickly.\n3. **Observe Best Practices:** By examining AI-generated code (which ideally reflects good practices), developers can learn new patterns and techniques.\n4. **Get Explanations on Demand:** Developers can ask the AI to explain complex concepts or unfamiliar code, acting as an always-available tutor.\n5. **Reduce Fear of Experimentation:** The ease of generating or refactoring code with AI can encourage developers to explore more, knowing they can easily revert or try again.\n\n**Key mechanisms:**\n\n* **Skill Leveling Effect:** Less experienced developers benefit more from AI assistance, helping bridge gaps between junior and senior developers.\n* **Adaptive Scaffolding:** AI provides guidance at the edge of the learner's ability (Zone of Proximal Development), with support fading as competence grows.\n* **Deliberate Practice at Scale:** 24/7 availability enables goal-oriented, feedback-driven practice with infinite patience for repetition.\n\nThis creates an environment where developers, particularly those less experienced, can learn and refine their skills at an accelerated pace by having a powerful, responsive partner in the coding process.",
+    "ko": "AI 에이전트를 개발자의 스킬 습득과 '취향' 개발을 가속화하는 대화형 학습 도구로 활용합니다. AI 코딩 어시스턴트를 사용하여 개발자는 다음을 수행할 수 있습니다:\n\n1. **빠른 반복:** 다양한 접근 방식을 빠르게 시도하고 즉각적인 결과나 피드백(예: 컴파일러 오류, 테스트 실패, AI 생성 대안)을 확인합니다.\n2. **효율적인 실수 학습:** AI가 오류를 식별하고 설명하여 개발자가 실패 원인을 더 빠르게 이해할 수 있습니다.\n3. **모범 사례 관찰:** AI 생성 코드(이상적으로 좋은 관행을 반영)를 검토하여 새로운 패턴과 기법을 학습합니다.\n4. **주문형 설명:** AI에게 복잡한 개념이나 익숙하지 않은 코드를 설명해달라고 요청하여 항상 이용 가능한 튜터로 활용합니다.\n5. **실험에 대한 두려움 감소:** AI를 통한 코드 생성이나 리팩토링의 용이성이 개발자가 더 많이 탐구하도록 장려합니다.\n\n**핵심 메커니즘:**\n\n* **스킬 평준화 효과:** 경험이 적은 개발자가 AI 지원에서 더 큰 혜택을 받아 주니어와 시니어 개발자 간 격차를 줄입니다.\n* **적응형 스캐폴딩:** AI가 학습자의 능력 경계(근접 발달 영역)에서 안내를 제공하며, 역량이 성장하면 지원이 점차 줄어듭니다.\n* **대규모 의도적 연습:** 24시간 가용성으로 반복에 대한 무한한 인내심과 함께 목표 지향적, 피드백 기반 연습이 가능합니다.\n\n이는 특히 경험이 적은 개발자가 강력하고 반응성 있는 파트너와 함께 가속화된 속도로 스킬을 학습하고 정제할 수 있는 환경을 만듭니다."
   },
   "ascii_diagram": "┌─────────────────────────────────┐\n│      Developer Learning         │\n└───────────────┬─────────────────┘\n                │\n    ┌───────────┼───────────┐\n    │           │           │\n┌───▼───┐ ┌─────▼─────┐ ┌───▼───┐\n│Iterate│ │Learn from │ │Observe│\n│Faster │ │Mistakes   │ │Best   │\n│       │ │           │ │Practice│\n└───┬───┘ └─────┬─────┘ └───┬───┘\n    │           │           │\n    └───────────┼───────────┘\n                │\n┌───────────────▼─────────────────┐\n│   AI Agent as Learning Partner  │\n├─────────────────────────────────┤\n│ • Immediate feedback            │\n│ • Error explanations            │\n│ • Pattern suggestions           │\n│ • On-demand tutoring            │\n│ • Safe experimentation          │\n└───────────────┬─────────────────┘\n                │\n┌───────────────▼─────────────────┐\n│   Accelerated Skill Growth      │\n└─────────────────────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Developer] --> B[Try Approach]\n    B --> C{Works?}\n    C -->|No| D[AI Explains Error]\n    D --> E[Learn Why It Failed]\n    E --> B\n    C -->|Yes| F[AI Shows Alternatives]\n    F --> G[Learn Better Patterns]\n    G --> H[Skill Improvement]\n    H --> I[Ask AI Questions]\n    I --> J[On-Demand Learning]\n    J --> B",
   "code_example": "# AI as always-available tutor and learning accelerator\n\n# 1. Iterate Faster\n# Try different approaches, see immediate results\nresult = agent.try_approach(my_code)\nif result.has_errors:\n    print(agent.explain_errors(result))\n\n# 2. Learn from Mistakes Efficiently\n# AI explains WHY something failed\n# \"This failed because you're mutating state during render...\"\n\n# 3. Observe Best Practices\n# Examine AI-generated code to learn new patterns\n# \"Note how this uses the Builder pattern instead of many args\"\n\n# 4. Get Explanations on Demand\n# Press Cmd+L and ask Claude any question\n# \"How does this async/await pattern work?\"\n\n# 5. Experiment Without Fear\n# Easy to revert or try again\n# \"Let me try a different approach...\"",
   "when_to_use": {
-    "en": ["Junior developer onboarding", "Learning new languages/frameworks", "Understanding unfamiliar codebases", "Developing 'code taste' faster"],
-    "ko": ["주니어 개발자 온보딩", "새 언어/프레임워크 학습", "익숙하지 않은 코드베이스 이해", "더 빠른 '코드 취향' 개발"]
+    "en": [
+      "Learning new frameworks or domains: Use AI to accelerate onboarding while maintaining independent problem-solving.",
+      "Deliberate practice: Ask for explanations and rationale, not just code. Request alternatives to compare approaches.",
+      "Fade support gradually: Start with heavy AI assistance, then reduce as competence builds to preserve skill development.",
+      "Socratic interaction: Have AI ask questions rather than give answers to build understanding and judgment.",
+      "Code review partnerships: Use AI as a first-pass reviewer to expose different perspectives and patterns."
+    ],
+    "ko": [
+      "새 프레임워크나 도메인 학습: AI를 활용하여 독립적 문제 해결 능력을 유지하면서 온보딩을 가속화",
+      "의도적 연습: 코드뿐만 아니라 설명과 근거를 요청하고, 접근 방식 비교를 위해 대안을 요청",
+      "점진적 지원 축소: 처음에는 AI 지원을 많이 받다가 역량이 쌓이면 줄여서 스킬 개발을 보존",
+      "소크라테스식 상호작용: AI가 답을 주기보다 질문을 하게 하여 이해와 판단력을 구축",
+      "코드 리뷰 파트너십: AI를 1차 리뷰어로 활용하여 다양한 관점과 패턴을 접함"
+    ]
   },
   "pros": {
-    "en": ["Vastly accelerated iteration cycles", "Always-available tutor", "Safe experimentation environment", "Learn patterns from AI-generated code"],
-    "ko": ["크게 가속화된 반복 주기", "항상 이용 가능한 튜터", "안전한 실험 환경", "AI 생성 코드에서 패턴 학습"]
+    "en": [
+      "Accelerated skill acquisition, particularly for junior developers",
+      "24/7 availability with infinite patience",
+      "Personalized learning paths",
+      "Reduced fear of experimentation"
+    ],
+    "ko": [
+      "특히 주니어 개발자를 위한 가속화된 스킬 습득",
+      "무한한 인내심과 함께 24시간 가용성",
+      "개인화된 학습 경로",
+      "실험에 대한 두려움 감소"
+    ]
   },
   "cons": {
-    "en": ["May develop dependency on AI", "AI explanations may have errors", "Could skip fundamental understanding", "Less struggle may mean less retention"],
-    "ko": ["AI에 대한 의존성 개발 가능", "AI 설명에 오류가 있을 수 있음", "기본적인 이해를 건너뛸 수 있음", "덜 힘들면 덜 기억할 수 있음"]
+    "en": [
+      "Risk of superficial learning without independent problem-solving",
+      "Overreliance can inhibit skill formation",
+      "Requires metacognitive discipline to fade support appropriately"
+    ],
+    "ko": [
+      "독립적 문제 해결 없이 피상적 학습에 머물 위험",
+      "과도한 의존은 스킬 형성을 저해할 수 있음",
+      "지원을 적절히 줄이기 위한 메타인지적 규율 필요"
+    ]
   },
-  "tags": ["developer-productivity", "learning", "skill-acquisition", "iteration", "feedback", "education", "junior-developer"]
+  "tags": ["developer-productivity", "learning", "skill-acquisition", "iteration", "feedback", "taste-development", "education", "junior-developer"]
 }

--- a/src/data/patterns/discrete-phase-separation.json
+++ b/src/data/patterns/discrete-phase-separation.json
@@ -6,27 +6,27 @@
   "status": "emerging",
   "original_url": "https://claude.com/blog/building-companies-with-claude-code",
   "problem": {
-    "en": "Mixing research, planning, and implementation in one context degrades output quality and causes context pollution.",
-    "ko": "리서치, 계획, 구현을 하나의 컨텍스트에서 혼합하면 출력 품질이 저하되고 컨텍스트 오염이 발생합니다."
+    "en": "When AI agents attempt to simultaneously research, plan, and implement solutions, context contamination occurs. Competing priorities within a single conversation degrade output quality as the agent struggles to balance exploration, strategic thinking, and execution. This results in incomplete research, unclear plans, and suboptimal implementations.",
+    "ko": "AI 에이전트가 리서치, 계획, 구현을 동시에 시도하면 컨텍스트 오염이 발생합니다. 단일 대화 내에서 경쟁하는 우선순위가 출력 품질을 저하시키며, 에이전트는 탐색, 전략적 사고, 실행의 균형을 맞추기 어려워합니다. 이로 인해 불완전한 리서치, 불명확한 계획, 최적이 아닌 구현이 발생합니다."
   },
   "solution": {
-    "en": "Break workflows into isolated phases with clean handoffs and fresh contexts, using different models optimized for each phase.",
-    "ko": "깨끗한 핸드오프와 새로운 컨텍스트로 워크플로우를 격리된 단계로 분리하고, 각 단계에 최적화된 다른 모델을 사용합니다."
+    "en": "Break development workflows into isolated phases with clean handoffs between them. Each phase runs in a separate conversation with a fresh context window, focusing exclusively on its objective:\n\n**Research Phase (Opus 4.1):**\n- Deep exploration of requirements, existing code, and constraints\n- Comprehensive background investigation\n- No implementation concerns\n\n**Planning Phase (Opus 4.1):**\n- Create structured implementation roadmap\n- Define clear steps and dependencies\n- No coding distractions\n\n**Implementation Phase (Sonnet 4.5):**\n- Execute each plan step systematically\n- Focus purely on code quality and functionality\n- Leverage the distilled outputs from previous phases\n\n**Key principle:** Pass only distilled conclusions between phases, not full conversation history. This prevents context pollution while maintaining necessary information flow.",
+    "ko": "개발 워크플로우를 격리된 단계로 분리하고 단계 간 깨끗한 핸드오프를 수행합니다. 각 단계는 별도의 대화에서 새로운 컨텍스트 윈도우로 실행되며, 해당 목표에만 집중합니다:\n\n**리서치 단계 (Opus 4.1):**\n- 요구 사항, 기존 코드, 제약 조건에 대한 심층 탐색\n- 포괄적인 배경 조사\n- 구현 관련 고려 없음\n\n**계획 단계 (Opus 4.1):**\n- 구조화된 구현 로드맵 생성\n- 명확한 단계와 의존성 정의\n- 코딩 관련 방해 없음\n\n**구현 단계 (Sonnet 4.5):**\n- 각 계획 단계를 체계적으로 실행\n- 코드 품질과 기능에만 집중\n- 이전 단계의 정제된 출력 활용\n\n**핵심 원칙:** 전체 대화 기록이 아닌 정제된 결론만 단계 간에 전달합니다. 이를 통해 필요한 정보 흐름을 유지하면서 컨텍스트 오염을 방지합니다."
   },
   "ascii_diagram": "┌──────────┐\n│ Research │ (Opus)\n│  Phase   │\n└────┬─────┘\n     │ distilled findings\n┌────▼─────┐\n│ Planning │ (Opus)\n│  Phase   │\n└────┬─────┘\n     │ roadmap\n┌────▼─────┐\n│ Execute  │ (Sonnet)\n│  Phase   │\n└──────────┘",
   "mermaid_diagram": "flowchart LR\n    A[Research Phase] -->|Findings| B[Planning Phase]\n    B -->|Roadmap| C[Execution Phase]\n    style A fill:#e1f5ff\n    style B fill:#fff4e1\n    style C fill:#e8f5e9",
   "code_example": "# Phase 1: Research with Opus\nfindings = opus.research(codebase, requirements)\n\n# Phase 2: Planning with Opus (fresh context)\nplan = opus.plan(findings.summary)\n\n# Phase 3: Execute with Sonnet (fresh context)\nfor task in plan.tasks:\n    sonnet.execute(task)",
   "when_to_use": {
-    "en": ["Complex feature development", "New codebase exploration", "Large-scale refactoring"],
-    "ko": ["복잡한 기능 개발", "신규 코드베이스 탐색", "대규모 리팩토링"]
+    "en": ["Complex features requiring significant background research", "Refactoring projects where understanding existing code is critical", "New codebases where architectural decisions need careful consideration", "Any task where mixing research and implementation degrades quality"],
+    "ko": ["상당한 배경 리서치가 필요한 복잡한 기능", "기존 코드 이해가 중요한 리팩토링 프로젝트", "아키텍처 결정에 신중한 고려가 필요한 신규 코드베이스", "리서치와 구현을 혼합하면 품질이 저하되는 모든 작업"]
   },
   "pros": {
-    "en": ["Higher quality output", "Context pollution prevention", "Model strength utilization"],
-    "ko": ["높은 품질 출력", "컨텍스트 오염 방지", "모델별 강점 활용"]
+    "en": ["Higher quality outputs in each phase due to focused attention", "Prevents context contamination from competing objectives", "Deliberation before action improves tool use accuracy from 72% to 94% (Parisien et al. 2024)", "Leverages model-specific strengths (Opus for reasoning, Sonnet for execution)", "Clearer mental model for complex projects", "Easier to debug which phase introduced issues"],
+    "ko": ["집중된 주의로 각 단계에서 더 높은 품질의 출력", "경쟁하는 목표로부터의 컨텍스트 오염 방지", "행동 전 심사숙고로 도구 사용 정확도 72%에서 94%로 향상(Parisien et al. 2024)", "모델별 강점 활용(Opus는 추론, Sonnet은 실행)", "복잡한 프로젝트를 위한 더 명확한 멘탈 모델", "어떤 단계에서 문제가 발생했는지 디버깅 용이"]
   },
   "cons": {
-    "en": ["Requires explicit management", "Overkill for simple tasks"],
-    "ko": ["명시적 관리 필요", "간단한 작업에 과함"]
+    "en": ["Requires more explicit phase management and handoffs", "Planning overhead adds ~35% latency (Parisien et al. 2024)", "Requires discipline to maintain phase boundaries", "Information loss risk if handoffs are poorly structured", "Higher total token usage across multiple conversations"],
+    "ko": ["더 명시적인 단계 관리와 핸드오프 필요", "계획 오버헤드로 ~35% 지연 시간 추가(Parisien et al. 2024)", "단계 경계를 유지하기 위한 규율 필요", "핸드오프가 잘못 구조화되면 정보 손실 위험", "여러 대화에 걸쳐 더 높은 총 토큰 사용량"]
   },
   "tags": ["orchestration", "planning", "research", "context-management", "multi-model"]
 }

--- a/src/data/patterns/explicit-posterior-sampling-planner.json
+++ b/src/data/patterns/explicit-posterior-sampling-planner.json
@@ -6,27 +6,27 @@
   "status": "emerging",
   "original_url": "https://arxiv.org/abs/2504.20997",
   "problem": {
-    "en": "Agents relying on ad-hoc heuristics explore poorly, wasting tokens and API calls on dead ends.",
-    "ko": "임시 휴리스틱에 의존하는 에이전트는 탐색을 제대로 수행하지 못해 막다른 길에서 토큰과 API 호출을 낭비합니다."
+    "en": "Heuristic planning loops often over-exploit the first plausible strategy and under-explore alternatives. In uncertain environments, this drives repeated dead ends, unstable learning, and high token/API spend with little information gain.",
+    "ko": "휴리스틱 기반 계획 루프는 첫 번째 그럴듯한 전략을 과도하게 활용하고 대안 탐색을 소홀히 합니다. 불확실한 환경에서 이는 반복적인 막다른 길, 불안정한 학습, 그리고 정보 이득이 적은 높은 토큰/API 비용을 초래합니다."
   },
   "solution": {
-    "en": "Embed PSRL (Posterior Sampling for RL) inside the LLM's reasoning: maintain Bayesian posterior over task models, sample, compute optimal plan, execute, observe reward, update posterior.",
-    "ko": "LLM의 추론 내부에 PSRL(강화 학습을 위한 사후 샘플링)을 내장합니다: 작업 모델에 대한 베이지안 사후 분포 유지, 샘플링, 최적 계획 계산, 실행, 보상 관찰, 사후 분포 업데이트."
+    "en": "Embed a *fully specified* RL algorithm—Posterior Sampling for Reinforcement Learning (PSRL)—inside the LLM's reasoning:\n\n- Maintain a Bayesian posterior over task models.\n- Sample a model, compute an optimal plan/policy, execute, observe reward, update posterior.\n- Express each step in natural language so the core LLM can carry it out with tool calls.\n\nThe planner becomes an explicit exploration policy instead of an improvised chain of thoughts. By repeatedly sampling from the posterior, the agent balances exploration and exploitation with a principled uncertainty model rather than ad-hoc retries. This is Thompson sampling generalized to multi-state MDPs, with near-optimal regret bounds of O(√T).",
+    "ko": "완전히 명세된 RL 알고리즘인 PSRL(강화 학습을 위한 사후 샘플링)을 LLM의 추론 내부에 내장합니다:\n\n- 작업 모델에 대한 베이지안 사후 분포를 유지합니다.\n- 모델을 샘플링하고, 최적 계획/정책을 계산하고, 실행하고, 보상을 관찰하고, 사후 분포를 업데이트합니다.\n- 각 단계를 자연어로 표현하여 핵심 LLM이 도구 호출로 수행할 수 있게 합니다.\n\n플래너는 즉흥적인 사고 체인 대신 명시적 탐색 정책이 됩니다. 사후 분포에서 반복적으로 샘플링함으로써, 에이전트는 임시 재시도 대신 원칙적인 불확실성 모델로 탐색과 활용의 균형을 맞춥니다. 이는 톰슨 샘플링을 다중 상태 MDP로 일반화한 것으로, O(√T)의 근최적 후회 경계를 갖습니다."
   },
   "ascii_diagram": "┌─────────────────┐\n│ Bayesian Prior  │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ Sample Model    │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ Compute Optimal │\n│     Plan        │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│    Execute      │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ Observe Reward  │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│Update Posterior │\n└────────┬────────┘\n         │\n         └──→ (repeat)",
   "mermaid_diagram": "flowchart TD\n    A[Maintain Bayesian Posterior] --> B[Sample Task Model]\n    B --> C[Compute Optimal Plan]\n    C --> D[Execute with Tool Calls]\n    D --> E[Observe Reward]\n    E --> F[Update Posterior]\n    F --> A",
   "code_example": "# PSRL-style exploration in prompt\nprompt = '''\nMaintain a posterior over task models.\n\n1. Sample a model from current posterior\n2. Compute optimal plan for sampled model\n3. Execute plan step using tool calls\n4. Observe reward/outcome\n5. Update posterior with observation\n6. Repeat until task complete\n\nCurrent posterior: {posterior}\nTask: {task}\n'''",
   "when_to_use": {
-    "en": ["Exploration-heavy tasks", "Unknown environments", "Multi-step decision making"],
-    "ko": ["탐색 중심 작업", "미지의 환경", "다단계 의사 결정"]
+    "en": ["Wrap PSRL in a reusable prompt template or controller skeleton with explicit state variables (posterior, reward, horizon).", "Start in bounded environments with measurable reward signals and instrument posterior updates for debugging.", "For text-based environments, design a state abstraction (e.g., semantic hashing or embedding-based clustering) to map unstructured context to discrete MDP states."],
+    "ko": ["명시적 상태 변수(사후 분포, 보상, 호라이즌)를 갖는 재사용 가능한 프롬프트 템플릿 또는 컨트롤러 스켈레톤으로 PSRL을 래핑", "측정 가능한 보상 신호가 있는 한정된 환경에서 시작하고 디버깅을 위해 사후 분포 업데이트를 계측", "텍스트 기반 환경에서는 비구조적 컨텍스트를 이산 MDP 상태로 매핑하기 위한 상태 추상화(예: 시맨틱 해싱 또는 임베딩 기반 클러스터링) 설계"]
   },
   "pros": {
-    "en": ["Principled exploration", "Theoretically grounded", "Efficient token usage"],
-    "ko": ["원칙적인 탐색", "이론적 기반", "효율적인 토큰 사용"]
+    "en": ["More sample-efficient exploration", "Better decision consistency under uncertainty"],
+    "ko": ["더 효율적인 샘플 탐색", "불확실성 하에서 더 나은 의사 결정 일관성"]
   },
   "cons": {
-    "en": ["Complex to implement", "Requires RL understanding", "May be overkill for simple tasks"],
-    "ko": ["구현 복잡", "RL 이해 필요", "단순 작업에는 과도할 수 있음"]
+    "en": ["Higher implementation complexity", "Sensitive reward design", "Additional compute overhead", "Requires careful state abstraction for text environments"],
+    "ko": ["높은 구현 복잡도", "민감한 보상 설계", "추가 컴퓨팅 오버헤드", "텍스트 환경에 대한 신중한 상태 추상화 필요"]
   },
   "tags": ["RL", "PSRL", "exploration", "planning", "decision-making"]
 }

--- a/src/data/patterns/layered-configuration-context.json
+++ b/src/data/patterns/layered-configuration-context.json
@@ -3,30 +3,48 @@
   "title": "Layered Configuration Context",
   "title_ko": "계층화된 구성 컨텍스트",
   "category": "Context & Memory",
-  "status": "proposed",
-  "original_url": "https://lethain.com/agents-layered-configuration/",
+  "status": "established",
+  "original_url": "https://www.nibzard.com/claude-code",
   "problem": {
-    "en": "Agents need different configurations at global, project, and task levels, but flat config systems don't support this hierarchy.",
-    "ko": "에이전트가 글로벌, 프로젝트, 작업 수준에서 다른 구성이 필요하지만 플랫 구성 시스템은 이 계층을 지원하지 않습니다."
+    "en": "AI agents require relevant context to perform effectively. Providing this context manually in every prompt is cumbersome, and a one-size-fits-all global context is often too broad or too narrow. Different projects, users, and organizational policies may require different baseline information for the agent.",
+    "ko": "AI 에이전트가 효과적으로 작동하려면 관련 컨텍스트가 필요합니다. 매 프롬프트마다 이 컨텍스트를 수동으로 제공하는 것은 번거롭고, 일률적인 전역 컨텍스트는 종종 너무 광범위하거나 너무 좁습니다. 다른 프로젝트, 사용자, 조직 정책은 에이전트에 대해 서로 다른 기준 정보를 요구할 수 있습니다."
   },
   "solution": {
-    "en": "Implement multi-level configuration that merges global defaults, project settings, and task-specific overrides.",
-    "ko": "글로벌 기본값, 프로젝트 설정, 작업별 오버라이드를 병합하는 다중 수준 구성을 구현합니다."
+    "en": "Implement a system of layered configuration files (e.g., named `CLAUDE.md` or a similar convention) that the agent automatically discovers and loads based on their location in the file system hierarchy. This allows for:\n\n- **Enterprise/Organizational Context:** A root-level file (`/<enterprise_root>/CLAUDE.md`) for policies or information shared across all projects in an organization.\n- **User-Specific Global Context:** A file in the user's home directory (`~/.claude/CLAUDE.md`) for personal preferences, common tools, or notes shared across all their projects.\n- **Project-Specific Context:** A file within the project's root directory (`<project_root>/CLAUDE.md`), typically version-controlled, for project-specific instructions, architectural overviews, or key file descriptions.\n- **Project-Local Context:** A local, non-version-controlled file (`<project_root>/CLAUDE.local.md`) for individual overrides, temporary notes, or secrets relevant to the project for that user.\n\nThe agent intelligently merges or prioritizes these context layers, providing a rich, tailored baseline of information without manual intervention in each query.",
+    "ko": "에이전트가 파일 시스템 계층 구조에서의 위치를 기반으로 자동으로 검색하고 로드하는 계층화된 구성 파일 시스템(예: `CLAUDE.md` 또는 유사한 규칙)을 구현합니다. 이를 통해 다음이 가능합니다:\n\n- **기업/조직 컨텍스트:** 조직의 모든 프로젝트에 공유되는 정책이나 정보를 위한 루트 레벨 파일(`/<enterprise_root>/CLAUDE.md`).\n- **사용자별 전역 컨텍스트:** 모든 프로젝트에 걸쳐 공유되는 개인 환경설정, 일반 도구, 메모를 위한 사용자 홈 디렉토리 파일(`~/.claude/CLAUDE.md`).\n- **프로젝트별 컨텍스트:** 프로젝트별 지침, 아키텍처 개요, 주요 파일 설명을 위한 프로젝트 루트 디렉토리 내 파일(`<project_root>/CLAUDE.md`), 일반적으로 버전 관리됨.\n- **프로젝트 로컬 컨텍스트:** 해당 사용자의 프로젝트에 관련된 개별 오버라이드, 임시 메모, 시크릿을 위한 로컬 비버전 관리 파일(`<project_root>/CLAUDE.local.md`).\n\n에이전트가 이러한 컨텍스트 레이어를 지능적으로 병합하거나 우선순위를 지정하여, 각 쿼리에서 수동 개입 없이 풍부하고 맞춤화된 기준 정보를 제공합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│   Global    │ ~/.agent/config\n│  Defaults   │\n└──────┬──────┘\n       │ merge\n┌──────▼──────┐\n│  Project    │ .agent/config\n│  Settings   │\n└──────┬──────┘\n       │ merge\n┌──────▼──────┐\n│   Task      │ inline/flags\n│ Overrides   │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│   Final     │\n│   Config    │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Global: ~/.agent/config] --> D[Merge]\n    B[Project: .agent/config] --> D\n    C[Task: inline flags] --> D\n    D --> E[Final Configuration]\n    E --> F[Agent Execution]",
   "code_example": "class LayeredConfig:\n    def __init__(self):\n        self.global_config = load('~/.agent/config')\n        self.project_config = load('.agent/config')\n    \n    def get_config(self, task_overrides=None):\n        config = {**self.global_config}\n        config.update(self.project_config)\n        if task_overrides:\n            config.update(task_overrides)\n        return config",
   "when_to_use": {
-    "en": ["Multi-project environments", "Team shared configurations", "Task-specific tuning"],
-    "ko": ["다중 프로젝트 환경", "팀 공유 구성", "작업별 튜닝"]
+    "en": [
+      "Use this when model quality depends on selecting or retaining the right context.",
+      "Start with strict context budgets and explicit memory retention rules.",
+      "Measure relevance and retrieval hit-rate before increasing memory breadth.",
+      "Version-control project context (`CLAUDE.md`); exclude local overrides (`CLAUDE.local.md`) from VCS."
+    ],
+    "ko": [
+      "모델 품질이 올바른 컨텍스트 선택이나 유지에 의존할 때 사용",
+      "엄격한 컨텍스트 예산과 명시적 메모리 유지 규칙으로 시작",
+      "메모리 범위를 늘리기 전에 관련성과 검색 적중률을 측정",
+      "프로젝트 컨텍스트(`CLAUDE.md`)는 버전 관리하고, 로컬 오버라이드(`CLAUDE.local.md`)는 VCS에서 제외"
+    ]
   },
   "pros": {
-    "en": ["Flexibility", "DRY configuration", "Easy overrides"],
-    "ko": ["유연성", "DRY 구성", "쉬운 오버라이드"]
+    "en": [
+      "Raises answer quality by keeping context relevant and reducing retrieval noise; enables enterprise-wide policy enforcement; supports automatic context loading without manual intervention"
+    ],
+    "ko": [
+      "컨텍스트를 관련성 있게 유지하고 검색 노이즈를 줄여 답변 품질을 높임; 기업 전체 정책 적용 가능; 수동 개입 없이 자동 컨텍스트 로딩 지원"
+    ]
   },
   "cons": {
-    "en": ["Debugging complexity", "Merge conflict resolution"],
-    "ko": ["디버깅 복잡성", "병합 충돌 해결"]
+    "en": [
+      "Requires ongoing tuning of memory policies and indexing quality; context window limits may truncate layers; potential for configuration conflicts"
+    ],
+    "ko": [
+      "메모리 정책과 인덱싱 품질의 지속적 튜닝 필요; 컨텍스트 윈도우 제한으로 레이어가 잘릴 수 있음; 구성 충돌 가능성"
+    ]
   },
-  "tags": ["configuration", "layered-config", "context-management", "hierarchy"]
+  "tags": ["context management", "configuration", "scoped context", "automatic loading", "CLAUDE.md"]
 }

--- a/src/data/patterns/llm-friendly-api-design.json
+++ b/src/data/patterns/llm-friendly-api-design.json
@@ -6,27 +6,43 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=BGgsoIgbT_Y",
   "problem": {
-    "en": "APIs designed solely for human consumption might be ambiguous or overly complex for an LLM to use correctly without extensive fine-tuning or elaborate prompting.",
-    "ko": "인간 소비만을 위해 설계된 API는 광범위한 미세조정이나 정교한 프롬프팅 없이는 LLM이 올바르게 사용하기에 모호하거나 지나치게 복잡할 수 있습니다."
+    "en": "For AI agents to reliably and effectively use tools, especially APIs or internal libraries, the design of these interfaces matters. APIs designed solely for human consumption might be ambiguous or overly complex for an LLM to use correctly without extensive fine-tuning or elaborate prompting.",
+    "ko": "AI 에이전트가 도구, 특히 API나 내부 라이브러리를 신뢰성 있고 효과적으로 사용하려면 이러한 인터페이스의 설계가 중요합니다. 인간 소비만을 위해 설계된 API는 광범위한 미세조정이나 정교한 프롬프팅 없이는 LLM이 올바르게 사용하기에 모호하거나 지나치게 복잡할 수 있습니다."
   },
   "solution": {
-    "en": "Design APIs with LLM consumption in mind: explicit versioning visible to model, self-descriptive function names, simplified interaction patterns, clear error messaging, reduced indirection levels.",
-    "ko": "LLM 소비를 염두에 둔 API 설계: 모델에 보이는 명시적 버전 관리, 자기 설명적 함수 이름, 단순화된 상호작용 패턴, 명확한 오류 메시지, 감소된 간접 수준."
+    "en": "Design or adapt software APIs (including internal libraries and modules) with explicit consideration for LLM consumption. This involves:\n\n- **Explicit Versioning:** Making API version information clearly visible and understandable to the LLM, so it can request or adapt to specific versions.\n- **Self-Descriptive Functionality:** Ensuring function names, parameter names, type schemas (JSON Schema/OpenAPI), and documentation clearly describe what the API does and how to use it.\n- **Simplified Interaction Patterns:** Favoring simpler, more direct API calls over highly nested or complex interaction sequences where possible, to reduce the chances of the LLM making errors.\n- **Clear Error Messaging:** Designing error responses that are informative and actionable for an LLM, helping it to self-correct or understand why a call failed.\n- **Reduced Indirection:** Structuring code and libraries to minimize layers of indirection (target: 2 levels instead of n-levels), making it easier for the model to reason about the codebase.\n\nThe aim is to create interfaces that are robust and intuitive for LLMs to interact with, thereby improving the reliability and effectiveness of agent tool use.",
+    "ko": "LLM 소비를 명시적으로 고려하여 소프트웨어 API(내부 라이브러리와 모듈 포함)를 설계하거나 조정합니다. 여기에는 다음이 포함됩니다:\n\n- **명시적 버전 관리:** API 버전 정보를 LLM이 명확하게 보고 이해할 수 있도록 하여 특정 버전을 요청하거나 적응할 수 있게 합니다.\n- **자기 설명적 기능:** 함수 이름, 파라미터 이름, 타입 스키마(JSON Schema/OpenAPI), 문서가 API의 기능과 사용 방법을 명확하게 설명하도록 합니다.\n- **단순화된 상호작용 패턴:** 가능한 경우 고도로 중첩되거나 복잡한 상호작용 시퀀스보다 더 단순하고 직접적인 API 호출을 선호하여 LLM의 오류 가능성을 줄입니다.\n- **명확한 오류 메시지:** LLM이 자기 수정하거나 호출 실패 이유를 이해할 수 있도록 정보가 풍부하고 실행 가능한 오류 응답을 설계합니다.\n- **간접 참조 감소:** 코드와 라이브러리를 구조화하여 간접 참조 레이어를 최소화(목표: n단계 대신 2단계)하여 모델이 코드베이스에 대해 추론하기 쉽게 합니다.\n\n목표는 LLM이 상호작용하기에 견고하고 직관적인 인터페이스를 만들어 에이전트 도구 사용의 신뢰성과 효과성을 향상시키는 것입니다."
   },
   "ascii_diagram": "HUMAN-CENTRIC API:\n├── Complex nested calls\n├── Implicit versioning\n├── Ambiguous error codes\n└── Many indirection levels\n\nLLM-FRIENDLY API:\n├── Flat, direct calls\n├── Visible version: v2.1.0\n├── Actionable error messages\n└── 2 levels of indirection max",
   "mermaid_diagram": "flowchart TD\n    A[API Design] --> B{Consumer Focus}\n    B -->|Human-Centric| C[Implicit Versions]\n    C --> D[Nested Calls]\n    D --> E[LLM Struggles]\n    B -->|LLM-Friendly| F[Explicit Versions]\n    F --> G[Self-Descriptive Names]\n    G --> H[Clear Errors]\n    H --> I[Reduced Indirection]\n    I --> J[LLM Success]",
   "code_example": "# Human-centric (problematic for LLM)\nresult = client.v2.users.get_by_id(id).profile.settings\n# Ambiguous: what version? many indirections\n\n# LLM-friendly design\nresult = get_user_settings(\n    user_id=123,\n    api_version='v2.1.0'  # Explicit, visible\n)\n# Error: {'code': 'USER_NOT_FOUND', \n#         'action': 'Verify user_id exists before calling'}",
   "when_to_use": {
-    "en": ["Building tools for AI agents", "Internal libraries for automation", "Public APIs expecting AI consumers"],
-    "ko": ["AI 에이전트용 도구 구축", "자동화를 위한 내부 라이브러리", "AI 소비자를 기대하는 공개 API"]
+    "en": [
+      "Use this when agent success depends on reliable tool invocation and environment setup.",
+      "Start with a narrow tool surface and explicit parameter validation.",
+      "Add observability around tool latency, failures, and fallback paths."
+    ],
+    "ko": [
+      "에이전트 성공이 신뢰성 있는 도구 호출과 환경 설정에 의존할 때 사용",
+      "좁은 도구 표면과 명시적 파라미터 검증으로 시작",
+      "도구 지연, 실패, 대체 경로에 대한 관찰 가능성 추가"
+    ]
   },
   "pros": {
-    "en": ["Improved reliability", "Fewer LLM errors", "Better self-correction"],
-    "ko": ["향상된 신뢰성", "LLM 오류 감소", "더 나은 자기 수정"]
+    "en": [
+      "Improves execution success and lowers tool-call failure rates"
+    ],
+    "ko": [
+      "실행 성공률을 높이고 도구 호출 실패율을 낮춤"
+    ]
   },
   "cons": {
-    "en": ["May sacrifice human ergonomics", "Requires intentional design effort"],
-    "ko": ["인간 인체공학 희생 가능", "의도적인 설계 노력 필요"]
+    "en": [
+      "Introduces integration coupling and environment-specific upkeep"
+    ],
+    "ko": [
+      "통합 결합도와 환경별 유지보수 부담 발생"
+    ]
   },
-  "tags": ["api-design", "llm-interaction", "tool-use", "system-design", "agent-compatibility"]
+  "tags": ["api-design", "llm-interaction", "tool-use", "system-design", "code-structure", "agent-compatibility"]
 }

--- a/src/data/patterns/self-rewriting-meta-prompt-loop.json
+++ b/src/data/patterns/self-rewriting-meta-prompt-loop.json
@@ -6,27 +6,27 @@
   "status": "emerging",
   "original_url": "https://noahgoodman.substack.com/p/meta-prompt-a-simple-self-improving",
   "problem": {
-    "en": "Static system prompts become stale or overly brittle as an agent encounters new tasks and edge cases.",
-    "ko": "정적 시스템 프롬프트가 에이전트가 새로운 작업과 엣지 케이스를 만날 때 오래되거나 취약해집니다."
+    "en": "Static system prompts become stale or overly brittle as an agent encounters new tasks and edge-cases. Manually editing them is slow and error-prone.",
+    "ko": "정적 시스템 프롬프트는 에이전트가 새로운 작업과 엣지 케이스를 만날 때 오래되거나 취약해집니다. 수동 편집은 느리고 오류가 발생하기 쉽습니다."
   },
   "solution": {
-    "en": "Let the agent rewrite its own system prompt after each interaction, validating changes before applying them.",
-    "ko": "에이전트가 각 상호작용 후 자체 시스템 프롬프트를 재작성하고, 적용 전에 변경 사항을 검증하게 합니다."
+    "en": "Let the agent **rewrite its own system prompt** after each interaction:\n\n1. **Reflect** on the latest dialogue or episode.\n2. Draft improvements to the instructions (add heuristics, refine tool advice, retire bad rules).\n3. **Validate** the draft (internal sanity-check or external gate).\n4. Replace the old system prompt with the revised version; persist in version control.\n5. Use the new prompt on the next episode, closing the self-improvement loop.\n\n```python\n# pseudo-code\ndialogue = run_episode()\ndelta = LLM(\"Reflect on dialogue and propose prompt edits\", dialogue)\nif passes_guardrails(delta):\n    system_prompt += delta\n    save(system_prompt)\n```",
+    "ko": "에이전트가 각 상호작용 후 **자체 시스템 프롬프트를 재작성**하게 합니다:\n\n1. 최신 대화 또는 에피소드에 대해 **반성**합니다.\n2. 지시 사항에 대한 개선 초안을 작성합니다(휴리스틱 추가, 도구 조언 정제, 나쁜 규칙 폐기).\n3. 초안을 **검증**합니다(내부 정합성 검사 또는 외부 게이트).\n4. 이전 시스템 프롬프트를 수정된 버전으로 교체하고 버전 관리에 유지합니다.\n5. 다음 에피소드에서 새 프롬프트를 사용하여 자기 개선 루프를 완성합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│  Dialogue   │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│   Reflect   │\n│ on Episode  │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│ Draft Edits │\n│ to Prompt   │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│  Validate   │\n│ (Guardrails)│\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│   Apply &   │\n│    Save     │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Run Episode] --> B[Reflect on Dialogue]\n    B --> C[Draft Prompt Improvements]\n    C --> D{Passes Guardrails?}\n    D -->|Yes| E[Update System Prompt]\n    D -->|No| F[Reject Changes]\n    E --> G[Save to Version Control]\n    G --> H[Next Episode]",
   "code_example": "dialogue = run_episode()\ndelta = LLM('Reflect on dialogue and propose prompt edits', dialogue)\nif passes_guardrails(delta):\n    system_prompt += delta\n    save_version(system_prompt)",
   "when_to_use": {
-    "en": ["Long-running agents", "Adaptive systems", "Continuous improvement"],
-    "ko": ["장기 실행 에이전트", "적응형 시스템", "지속적 개선"]
+    "en": ["Best for low-risk domains with high-volume, well-defined workflows (e.g., formatting, style)", "Requires strong guardrails: structural validation, intent preservation checks, change magnitude limits", "Include version control integration and rollback capability", "Consider dual-agent architecture (executor + critic) for safer delta generation", "Avoid in safety-critical or high-regulation domains without human approval gates"],
+    "ko": ["대량의 잘 정의된 워크플로우가 있는 저위험 도메인에 적합(예: 포매팅, 스타일)", "강력한 가드레일 필요: 구조적 검증, 의도 보존 검사, 변경 규모 제한", "버전 관리 통합 및 롤백 기능 포함", "더 안전한 델타 생성을 위한 이중 에이전트 아키텍처(실행자 + 비평자) 고려", "인간 승인 게이트 없이 안전 필수 또는 고규제 도메인에서는 사용 금지"]
   },
   "pros": {
-    "en": ["Rapid adaptation", "No human in loop for minor tweaks"],
-    "ko": ["빠른 적응", "사소한 조정에 인간 개입 불필요"]
+    "en": ["Rapid adaptation", "Data-driven improvements", "No training infrastructure required"],
+    "ko": ["빠른 적응", "데이터 기반 개선", "학습 인프라 불필요"]
   },
   "cons": {
-    "en": ["Risk of drift or jailbreak", "Needs strong guardrails"],
-    "ko": ["드리프트나 탈옥 위험", "강력한 가드레일 필요"]
+    "en": ["Risk of drift or jailbreak", "Prompt bloat", "Oscillation and instability"],
+    "ko": ["드리프트나 탈옥 위험", "프롬프트 비대화", "진동 및 불안정성"]
   },
   "tags": ["meta-prompting", "self-improvement", "system-prompt", "reflection"]
 }

--- a/src/data/patterns/shell-command-contextualization.json
+++ b/src/data/patterns/shell-command-contextualization.json
@@ -6,27 +6,27 @@
   "status": "established",
   "original_url": "https://www.nibzard.com/claude-code",
   "problem": {
-    "en": "Manually copying shell command output into prompts is tedious and error-prone.",
-    "ko": "셸 명령 출력을 프롬프트에 수동으로 복사하는 것은 지루하고 오류가 발생하기 쉽습니다."
+    "en": "When an AI agent interacts with a local development environment, it often needs to execute shell commands (e.g., run linters, check git status, list files) and then use the output of these commands as context for its subsequent reasoning or actions. Manually copying and pasting command output into the prompt is tedious and error-prone.",
+    "ko": "AI 에이전트가 로컬 개발 환경과 상호작용할 때, 셸 명령(예: 린터 실행, git 상태 확인, 파일 목록 조회)을 실행하고 그 출력을 후속 추론이나 작업의 컨텍스트로 사용해야 하는 경우가 많습니다. 명령 출력을 프롬프트에 수동으로 복사하고 붙여넣는 것은 지루하고 오류가 발생하기 쉽습니다."
   },
   "solution": {
-    "en": "Provide a mechanism (e.g., ! prefix) to execute shell commands and automatically inject both command and output into agent context.",
-    "ko": "셸 명령을 실행하고 명령과 출력을 모두 에이전트 컨텍스트에 자동으로 주입하는 메커니즘(예: ! 접두사)을 제공합니다."
+    "en": "Provide a dedicated mechanism within the agent's interface (e.g., a special prefix like `!` or a specific command mode) that allows the user to directly issue a shell command to be executed in the local environment. Crucially, both the command itself and its full output (stdout and stderr) are automatically captured and injected into the agent's current conversational or working context.\n\nThe `!` prefix syntax originates from IPython (2001) and has become the de facto standard across AI coding platforms (Claude Code, Cursor, GitHub Copilot, Continue.dev, Aider, Replit Agent).\n\nThis ensures that the agent is immediately aware of the command that was run and its results, allowing it to seamlessly incorporate this information into its ongoing tasks without requiring manual data transfer by the user.",
+    "ko": "에이전트 인터페이스 내에 전용 메커니즘(예: `!` 같은 특수 접두사 또는 특정 명령 모드)을 제공하여, 사용자가 로컬 환경에서 셸 명령을 직접 실행할 수 있게 합니다. 핵심적으로, 명령 자체와 전체 출력(stdout 및 stderr)이 자동으로 캡처되어 에이전트의 현재 대화 또는 작업 컨텍스트에 주입됩니다.\n\n`!` 접두사 구문은 IPython(2001)에서 유래하여 AI 코딩 플랫폼(Claude Code, Cursor, GitHub Copilot, Continue.dev, Aider, Replit Agent) 전반의 사실상 표준이 되었습니다.\n\n이를 통해 에이전트는 실행된 명령과 그 결과를 즉시 인식하며, 사용자의 수동 데이터 전달 없이 진행 중인 작업에 이 정보를 원활하게 통합할 수 있습니다."
   },
   "ascii_diagram": "┌─────────────┐\n│User: !ls -la│\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│  Execute    │\n│  ls -la     │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│Command +    │\n│Output →     │\n│  Context    │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│Agent aware  │\n│of results   │\n└─────────────┘",
   "mermaid_diagram": "sequenceDiagram\n    participant User\n    participant Interface\n    participant Shell\n    participant Agent\n\n    User->>Interface: !ls -la\n    Interface->>Shell: Execute: ls -la\n    Shell-->>Interface: Command output\n    Interface->>Agent: Inject command + output\n    Agent-->>User: Response with shell context",
   "code_example": "# In Claude Code, typing !ls -la executes locally\n# Both command and output are added to context\n\n$ !git status\n# → Executes git status\n# → Adds \"$ git status\\n<output>\" to Claude's context\n# → Claude can now reason about the repo state",
   "when_to_use": {
-    "en": ["Development environments", "System administration tasks", "Build/test workflows"],
-    "ko": ["개발 환경", "시스템 관리 작업", "빌드/테스트 워크플로우"]
+    "en": ["When agent success depends on reliable tool invocation and environment setup", "Implement PTY-aware execution with graceful fallback for non-interactive commands", "Validate commands before execution (allowlist-based, dangerous pattern detection)", "Capture full output (stdout, stderr, exit codes) for complete context", "Add observability around tool latency, failures, and fallback paths"],
+    "ko": ["에이전트 성공이 신뢰할 수 있는 도구 호출과 환경 설정에 의존하는 경우", "비대화형 명령에 대한 그레이스풀 폴백이 있는 PTY 인식 실행 구현", "실행 전 명령 검증(허용 목록 기반, 위험 패턴 감지)", "완전한 컨텍스트를 위해 전체 출력(stdout, stderr, 종료 코드) 캡처", "도구 지연, 실패, 폴백 경로에 대한 관찰 가능성 추가"]
   },
   "pros": {
-    "en": ["Seamless integration", "Real-time system awareness", "Reduced copy-paste"],
-    "ko": ["원활한 통합", "실시간 시스템 인식", "복사-붙여넣기 감소"]
+    "en": ["Eliminates manual copy-paste workflow", "Enables seamless context injection", "Universal adoption provides mature implementations", "Strong academic foundations (ToolFormer, ReAct, RAG)"],
+    "ko": ["수동 복사-붙여넣기 워크플로우 제거", "원활한 컨텍스트 주입 가능", "범용적 채택으로 성숙한 구현체 제공", "강력한 학술적 기반(ToolFormer, ReAct, RAG)"]
   },
   "cons": {
-    "en": ["Security considerations for arbitrary execution", "Output size limits"],
-    "ko": ["임의 실행에 대한 보안 고려", "출력 크기 제한"]
+    "en": ["Introduces integration coupling and environment-specific upkeep", "Requires security considerations (validation, sandboxing)", "Output size can impact token costs"],
+    "ko": ["통합 결합도 및 환경별 유지 관리 발생", "보안 고려 사항 필요(검증, 샌드박싱)", "출력 크기가 토큰 비용에 영향"]
   },
   "tags": ["shell-integration", "context-management", "local-execution", "cli"]
 }

--- a/src/data/patterns/tool-capability-compartmentalization.json
+++ b/src/data/patterns/tool-capability-compartmentalization.json
@@ -6,27 +6,47 @@
   "status": "emerging",
   "original_url": "https://simonwillison.net/2025/Jun/16/lethal-trifecta/",
   "problem": {
-    "en": "MCP encourages mix-and-match tools, often combining private-data readers, web fetchers, and writers in a single callable unit. This amplifies the lethality of prompt-injection chains.",
-    "ko": "MCP는 혼합 도구를 권장하며, 종종 개인 데이터 리더, 웹 페처, 라이터를 단일 호출 가능 단위로 결합합니다. 이는 프롬프트 인젝션 체인의 치명성을 증폭시킵니다."
+    "en": "Model Context Protocol (MCP) and agent frameworks often combine three capability classes in a single tool: private-data readers (email, filesystem), web fetchers (HTTP clients), and writers (API mutators). This creates the \"lethal trifecta\"--malicious input can trigger chains that read sensitive data, exfiltrate it, and modify systems in one operation.",
+    "ko": "MCP(Model Context Protocol)와 에이전트 프레임워크는 종종 단일 도구에 세 가지 기능 클래스를 결합합니다: 개인 데이터 리더(이메일, 파일시스템), 웹 페처(HTTP 클라이언트), 라이터(API 뮤테이터). 이는 '치명적 삼중주(lethal trifecta)'를 생성하여, 악의적 입력이 민감한 데이터를 읽고, 유출하고, 시스템을 수정하는 체인을 단일 작업으로 트리거할 수 있습니다."
   },
   "solution": {
-    "en": "Split monolithic tools into reader, processor, and writer micro-tools. Require explicit per-call user consent when composing tools across capability classes. Run each class in isolated subprocess with scoped permissions.",
-    "ko": "모놀리식 도구를 리더, 프로세서, 라이터 마이크로 도구로 분할합니다. 기능 클래스 간 도구를 구성할 때 명시적인 호출별 사용자 동의를 요구합니다. 각 클래스를 범위가 지정된 권한으로 격리된 서브프로세스에서 실행합니다."
+    "en": "Adopt **capability compartmentalization** at the tool layer:\n\n- Split monolithic tools into *reader*, *processor*, and *writer* micro-tools.\n- Require explicit, per-call user consent when composing tools across capability classes.\n- Run each class in an isolated subprocess with scoped API keys and file permissions.\n\nTreat each capability class as a separate trust zone with its own runtime identity and policy checks. Cross-zone composition should require explicit policy evaluation and short-lived delegation tokens so the agent cannot silently chain read+fetch+write into a high-risk path.\n\n```yaml\n# tool-manifest.yml\nemail_reader:\n  capabilities: [private_data, untrusted_input]\n  permissions:\n    fs: read-only:/mail\n    net: none\n\nissue_creator:\n  capabilities: [external_comm]\n  permissions:\n    net: allowlist:github.com\n```",
+    "ko": "도구 레이어에서 **기능 구획화**를 적용합니다:\n\n- 모놀리식 도구를 *리더*, *프로세서*, *라이터* 마이크로 도구로 분할합니다.\n- 기능 클래스 간 도구를 구성할 때 명시적인 호출별 사용자 동의를 요구합니다.\n- 각 클래스를 범위가 지정된 API 키와 파일 권한으로 격리된 서브프로세스에서 실행합니다.\n\n각 기능 클래스를 자체 런타임 아이덴티티와 정책 검사를 가진 별도의 신뢰 영역으로 취급합니다. 영역 간 구성은 명시적 정책 평가와 단기 위임 토큰을 요구하여 에이전트가 읽기+페치+쓰기를 고위험 경로로 조용히 체이닝할 수 없도록 합니다."
   },
   "ascii_diagram": "┌─────────────────────────────────────┐\n│      MONOLITHIC TOOL (Bad)          │\n│  [read_email + fetch_web + write]   │\n│         → Security Risk!            │\n└─────────────────────────────────────┘\n                  ↓\n┌─────────────────────────────────────┐\n│   COMPARTMENTALIZED (Good)          │\n├─────────────────────────────────────┤\n│ email_reader:                       │\n│   capabilities: [private_data]      │\n│   permissions: fs:read-only, net:no │\n├─────────────────────────────────────┤\n│ issue_creator:                      │\n│   capabilities: [external_comm]     │\n│   permissions: net:github.com only  │\n└─────────────────────────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Tool Request] --> B{Check Manifest}\n    B --> C[Reader Tool]\n    B --> D[Processor Tool]\n    B --> E[Writer Tool]\n    C --> F{Crosses Capability Class?}\n    D --> F\n    E --> F\n    F -->|Yes| G[Request User Consent]\n    F -->|No| H[Execute in Sandbox]\n    G --> H",
   "code_example": "# tool-manifest.yml\nemail_reader:\n  capabilities: [private_data, untrusted_input]\n  permissions:\n    fs: read-only:/mail\n    net: none\n\nissue_creator:\n  capabilities: [external_comm]\n  permissions:\n    net: allowlist:github.com\n\n# Agent runner checks manifest before action plans\n# Flags any attempt to chain tools that recreate\n# the lethal trifecta",
   "when_to_use": {
-    "en": ["MCP tool design", "Security-sensitive agent systems", "Multi-tenant environments"],
-    "ko": ["MCP 도구 설계", "보안에 민감한 에이전트 시스템", "다중 테넌트 환경"]
+    "en": [
+      "Generate the manifest automatically from CI.",
+      "Your agent runner consults the manifest before constructing action plans.",
+      "Flag any attempt to chain tools that would recreate the lethal trifecta.",
+      "Group tools by capability class (fs, web, runtime, memory) and assign profiles (minimal, coding, messaging) to prevent mixing.",
+      "Validate tool chains at call time: reject if all three capability classes are present."
+    ],
+    "ko": [
+      "CI에서 매니페스트를 자동 생성",
+      "에이전트 러너가 액션 플랜 구성 전 매니페스트를 참조",
+      "치명적 삼중주를 재현하는 도구 체이닝 시도를 플래그 처리",
+      "기능 클래스(fs, web, runtime, memory)별로 도구를 그룹화하고 프로파일(minimal, coding, messaging)을 할당하여 혼합 방지",
+      "호출 시점에 도구 체인 검증: 세 가지 기능 클래스가 모두 존재하면 거부"
+    ]
   },
   "pros": {
-    "en": ["Fine-grained security", "Plays well with modular architectures", "Clear audit trail"],
-    "ko": ["세분화된 보안", "모듈식 아키텍처와 잘 호환", "명확한 감사 추적"]
+    "en": [
+      "Fine-grained; plays well with modular architectures"
+    ],
+    "ko": [
+      "세분화되어 모듈식 아키텍처와 잘 호환됨"
+    ]
   },
   "cons": {
-    "en": ["More tooling overhead", "Risk of permission creep over time", "Complexity in tool composition"],
-    "ko": ["더 많은 도구 오버헤드", "시간이 지남에 따라 권한 확대 위험", "도구 구성의 복잡성"]
+    "en": [
+      "More tooling overhead; risk of permission creep over time"
+    ],
+    "ko": [
+      "더 많은 도구 오버헤드; 시간이 지남에 따라 권한 확대 위험"
+    ]
   },
-  "tags": ["capability-segregation", "least-privilege", "tool-permissions", "security"]
+  "tags": ["capability-segregation", "least-privilege", "tool-permissions"]
 }

--- a/src/data/patterns/versioned-constitution-governance.json
+++ b/src/data/patterns/versioned-constitution-governance.json
@@ -6,27 +6,43 @@
   "status": "emerging",
   "original_url": "https://substack.com/home/post/p-161422949?utm_campaign=post&utm_medium=web",
   "problem": {
-    "en": "When an agent rewrites its own constitution (alignment rules), it may accidentally violate safety constraints or regress on alignment objectives if changes aren't properly reviewed and tracked.",
-    "ko": "에이전트가 자체 헌법(정렬 규칙)을 재작성할 때, 변경 사항이 적절히 검토되고 추적되지 않으면 안전 제약을 실수로 위반하거나 정렬 목표에서 후퇴할 수 있습니다."
+    "en": "When agents can modify policy/constitution text, safety regressions can be introduced gradually and go unnoticed. Without versioning, signatures, and policy review gates, teams cannot prove who changed what, why it changed, or whether critical safeguards were weakened.",
+    "ko": "에이전트가 정책/헌법 텍스트를 수정할 수 있을 때, 안전 후퇴가 점진적으로 도입되어 눈에 띄지 않을 수 있습니다. 버전 관리, 서명, 정책 리뷰 게이트가 없으면 누가 무엇을 변경했는지, 왜 변경했는지, 중요한 안전장치가 약화되었는지 증명할 수 없습니다."
   },
   "solution": {
-    "en": "Store the constitution in a version-controlled, signed repository. YAML/TOML rules live in Git with signed commits (Sigstore). CI runs automated policy checks. Agent can propose changes but only approved reviewers can merge.",
-    "ko": "헌법을 버전 관리되고 서명된 저장소에 저장합니다. YAML/TOML 규칙은 서명된 커밋(Sigstore)과 함께 Git에 있습니다. CI는 자동화된 정책 검사를 실행합니다. 에이전트는 변경을 제안할 수 있지만 승인된 검토자만 병합할 수 있습니다."
+    "en": "Store the constitution in a **version-controlled, signed repository**:\n\n- YAML/TOML rules live in Git for automated rule enforcement; natural language principles guide LLM-based evaluation.\n- Each commit is signed (e.g., Sigstore); CI runs automated policy checks.\n- Only commits signed by approved reviewers or automated tests are merged.\n- The agent can *propose* changes, but a gatekeeper merges them.\n- Use semantic versioning: MAJOR for core safety principle changes, MINOR for additions, PATCH for clarifications.\n\nCombine policy-as-code with release discipline: every constitutional change is diffable, reviewable, and test-gated before activation. This gives governance history, rollback capability, and auditable control over alignment policy evolution.",
+    "ko": "헌법을 **버전 관리되고 서명된 저장소**에 저장합니다:\n\n- YAML/TOML 규칙은 자동화된 규칙 적용을 위해 Git에 저장하고, 자연어 원칙은 LLM 기반 평가를 안내합니다.\n- 각 커밋은 서명되며(예: Sigstore), CI가 자동화된 정책 검사를 실행합니다.\n- 승인된 검토자 또는 자동화된 테스트가 서명한 커밋만 병합됩니다.\n- 에이전트는 변경을 *제안*할 수 있지만, 게이트키퍼가 병합합니다.\n- 시맨틱 버전 관리 사용: 핵심 안전 원칙 변경은 MAJOR, 추가는 MINOR, 명확화는 PATCH.\n\n정책을 코드로 관리하는 것과 릴리스 규율을 결합합니다: 모든 헌법 변경은 활성화 전에 diff 가능하고, 검토 가능하며, 테스트 게이트를 통과해야 합니다. 이를 통해 거버넌스 이력, 롤백 기능, 정렬 정책 진화에 대한 감사 가능한 제어를 제공합니다."
   },
   "ascii_diagram": "┌─────────────────────────────────┐\n│        Agent Runtime            │\n│  (reads constitution HEAD)      │\n└───────────────┬─────────────────┘\n                │ read-only\n┌───────────────▼─────────────────┐\n│    Git Repository               │\n│    (constitution.yaml)          │\n├─────────────────────────────────┤\n│  commit 3: v1.2 (current HEAD)  │\n│  commit 2: v1.1                 │\n│  commit 1: v1.0 (initial)       │\n└───────────────┬─────────────────┘\n                │\n        ┌───────┴───────┐\n        │               │\n┌───────▼───────┐ ┌─────▼─────────┐\n│ Agent Proposes│ │ Human Reviews │\n│ Changes (PR)  │ │ & Approves    │\n└───────────────┘ └───────┬───────┘\n                          │\n                  ┌───────▼───────┐\n                  │ CI Policy     │\n                  │ Checks        │\n                  └───────┬───────┘\n                          │\n                  ┌───────▼───────┐\n                  │ Signed Merge  │\n                  └───────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Agent Runtime] -->|read-only| B[Git Repo: constitution.yaml]\n    B --> C[Version History]\n    A -->|proposes| D[Pull Request]\n    D --> E[CI Policy Checks]\n    E --> F{Passes?}\n    F -->|Yes| G[Human Review]\n    F -->|No| H[Reject - Safety Violation]\n    G --> I{Approved?}\n    I -->|Yes| J[Signed Commit Merge]\n    I -->|No| K[Reject]\n    J --> B",
   "code_example": "# constitution.yaml - Version controlled alignment rules\nversion: 1.2\nrules:\n  - id: no_harmful_content\n    description: Never generate harmful or illegal content\n    severity: critical\n    \n  - id: respect_privacy\n    description: Do not expose personal information\n    severity: critical\n    \n  - id: cite_sources\n    description: Provide citations for factual claims\n    severity: warning\n\n# Git workflow\ngit commit -S -m 'Update rule: cite_sources'  # Signed commit\n# CI runs: python check_policy.py constitution.yaml\n# - Flags deletions of critical rules\n# - Validates rule schema\n# - Only approved reviewers can merge",
   "when_to_use": {
-    "en": ["Self-modifying agent systems", "Safety-critical alignment rules", "Multi-stakeholder AI governance", "Auditable AI systems"],
-    "ko": ["자기 수정 에이전트 시스템", "안전이 중요한 정렬 규칙", "다중 이해관계자 AI 거버넌스", "감사 가능한 AI 시스템"]
+    "en": [
+      "Require `git commit -S` or similar.",
+      "Run diff-based linting to flag deletions of critical rules.",
+      "Expose constitution `HEAD` as read-only context in every agent episode."
+    ],
+    "ko": [
+      "`git commit -S` 또는 유사한 서명 커밋 필수 적용",
+      "diff 기반 린팅으로 중요 규칙 삭제를 플래그 처리",
+      "모든 에이전트 에피소드에서 헌법 `HEAD`를 읽기 전용 컨텍스트로 노출"
+    ]
   },
   "pros": {
-    "en": ["Complete audit trail of changes", "Prevents accidental safety regression", "Multiple stakeholders can review", "Cryptographic integrity via signing"],
-    "ko": ["변경 사항의 완전한 감사 추적", "실수로 인한 안전 후퇴 방지", "여러 이해관계자가 검토 가능", "서명을 통한 암호화 무결성"]
+    "en": [
+      "Strong auditability, safer policy evolution, and fast rollback of bad constitutional changes"
+    ],
+    "ko": [
+      "강력한 감사 가능성, 더 안전한 정책 진화, 잘못된 헌법 변경의 빠른 롤백"
+    ]
   },
   "cons": {
-    "en": ["Slower iteration on rules", "Requires governance process", "May bottleneck rapid experimentation", "Git complexity for non-technical reviewers"],
-    "ko": ["규칙에 대한 느린 반복", "거버넌스 프로세스 필요", "빠른 실험의 병목이 될 수 있음", "비기술 검토자를 위한 Git 복잡성"]
+    "en": [
+      "Slower policy iteration and extra operational burden for signing, review, and CI checks"
+    ],
+    "ko": [
+      "느린 정책 반복과 서명, 리뷰, CI 검사를 위한 추가 운영 부담"
+    ]
   },
-  "tags": ["constitution", "alignment", "governance", "signed-commits", "policy", "safety"]
+  "tags": ["constitution", "alignment", "governance", "signed-commits", "policy", "rlaif", "critique-revise"]
 }


### PR DESCRIPTION
## Summary
이슈 #49의 Batch 7 - 변경 규모 61-70위 10개 패턴 업데이트.

## 업데이트된 패턴
- ai-accelerated-learning-and-skill-development
- tool-capability-compartmentalization
- llm-friendly-api-design
- versioned-constitution-governance
- layered-configuration-context (status: proposed → established)
- explicit-posterior-sampling-planner
- agentic-search-over-vector-embeddings
- shell-command-contextualization
- self-rewriting-meta-prompt-loop
- discrete-phase-separation

## Test plan
- [x] \`npm test\` 로컬 통과
- [x] JSON 유효성 검증

Part of #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)