### PR TITLE
feat: Update 10 patterns from upstream (batch 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 - 🧠 **Context & Memory** (19) - Sliding window, vector cache
 - 🔄 **Feedback Loops** (15) - Compiler, CI, self-healing retry
 - 📚 **Learning & Adaptation** (7) - Agent RFT, skill library
-- ✅ **Reliability & Eval** (18) - Guardrails, evaluation framework
+- ✅ **Reliability & Eval** (19) - Guardrails, evaluation framework
 - 🔒 **Security & Safety** (10) - Isolated VM, PII tokenization
-- 🔧 **Tool Use & Environment** (23) - Shell, browser, DB
+- 🔧 **Tool Use & Environment** (22) - Shell, browser, DB
 - 👥 **UX & Collaboration** (16) - Prompt handoff, step-by-step commit
 
 ---

--- a/README_KR.md
+++ b/README_KR.md
@@ -24,9 +24,9 @@
 - 🧠 **Context & Memory** (19개) - 슬라이딩 윈도우, 벡터 캐시
 - 🔄 **Feedback Loops** (15개) - 컴파일러, CI, 자가 치유 재시도
 - 📚 **Learning & Adaptation** (7개) - 에이전트 RFT, 스킬 라이브러리
-- ✅ **Reliability & Eval** (18개) - 가드레일, 평가 프레임워크
+- ✅ **Reliability & Eval** (19개) - 가드레일, 평가 프레임워크
 - 🔒 **Security & Safety** (10개) - 격리된 VM, PII 토큰화
-- 🔧 **Tool Use & Environment** (23개) - 셸, 브라우저, DB
+- 🔧 **Tool Use & Environment** (22개) - 셸, 브라우저, DB
 - 👥 **UX & Collaboration** (16개) - 프롬프트 핸드오프, 단계별 커밋
 
 ---

--- a/src/data/patterns/democratization-of-tooling-via-agents.json
+++ b/src/data/patterns/democratization-of-tooling-via-agents.json
@@ -6,27 +6,53 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=BGgsoIgbT_Y",
   "problem": {
-    "en": "Many individuals in non-software engineering roles (sales, marketing, operations) could benefit from custom software tools tailored to their workflows, but lack traditional programming skills to build them.",
-    "ko": "비소프트웨어 엔지니어링 역할(영업, 마케팅, 운영)의 많은 개인은 워크플로우에 맞춤화된 소프트웨어 도구의 혜택을 받을 수 있지만, 이를 구축할 전통적인 프로그래밍 기술이 부족합니다."
+    "en": "Many individuals in non-software engineering roles (e.g., sales, marketing, operations, communications) could benefit from custom software tools, scripts, or dashboards tailored to their specific workflows, but lack the traditional programming skills to build them.",
+    "ko": "비소프트웨어 엔지니어링 역할(예: 영업, 마케팅, 운영, 커뮤니케이션)의 많은 개인은 특정 워크플로우에 맞춤화된 소프트웨어 도구, 스크립트 또는 대시보드의 혜택을 받을 수 있지만, 이를 구축할 전통적인 프로그래밍 기술이 부족합니다."
   },
   "solution": {
-    "en": "Empower non-programmers to create or modify software using AI agents. Users describe desired tools in natural language, agents generate necessary code, and users iteratively refine with agent help. This democratizes software development to domain experts.",
-    "ko": "AI 에이전트를 사용하여 비프로그래머가 소프트웨어를 생성하거나 수정할 수 있도록 권한을 부여합니다. 사용자는 원하는 도구를 자연어로 설명하고, 에이전트는 필요한 코드를 생성하며, 사용자는 에이전트의 도움으로 반복적으로 개선합니다. 이는 도메인 전문가에게 소프트웨어 개발을 민주화합니다."
+    "en": "Empower a broader range of users, including those without deep coding expertise, to create or modify software solutions for their own needs using AI agents. With an AI agent as an assistant, these users can:\n1. Describe their desired tool or functionality in natural language.\n2. Have the agent generate the necessary code (e.g., for a dashboard, a script to automate a task, a simple web application).\n3. Iteratively refine the tool with the agent's help.\n4. Even perform simple bug fixes or modifications to existing tools or codebases.\n\nThis pattern lowers the barrier to software creation, allowing domain experts in various fields to build their own productivity tools, thereby \"democratizing\" software development to some extent.",
+    "ko": "깊은 코딩 전문 지식이 없는 사용자를 포함한 더 넓은 범위의 사용자가 AI 에이전트를 사용하여 자신의 필요에 맞는 소프트웨어 솔루션을 생성하거나 수정할 수 있도록 합니다. AI 에이전트를 어시스턴트로 활용하여 사용자는:\n1. 원하는 도구나 기능을 자연어로 설명합니다.\n2. 에이전트가 필요한 코드를 생성합니다(예: 대시보드, 작업 자동화 스크립트, 간단한 웹 애플리케이션).\n3. 에이전트의 도움으로 도구를 반복적으로 개선합니다.\n4. 기존 도구나 코드베이스에 대한 간단한 버그 수정이나 수정도 수행합니다.\n\n이 패턴은 소프트웨어 생성의 장벽을 낮추어 다양한 분야의 도메인 전문가가 자체 생산성 도구를 구축할 수 있게 하여 소프트웨어 개발을 어느 정도 \"민주화\"합니다."
   },
   "ascii_diagram": "┌─────────────────────────────────┐\n│   Non-Technical User            │\n│   (Sales, Marketing, Ops)       │\n└───────────────┬─────────────────┘\n                │ Natural Language\n                │ Description\n┌───────────────▼─────────────────┐\n│         AI Agent                │\n│   • Understands intent          │\n│   • Generates code              │\n│   • Explains changes            │\n└───────────────┬─────────────────┘\n                │\n┌───────────────▼─────────────────┐\n│      Generated Tool             │\n│   • Dashboard                   │\n│   • Automation script           │\n│   • Simple web app              │\n└───────────────┬─────────────────┘\n                │\n        ┌───────┴───────┐\n        │ Iterate       │\n        │ & Refine      │\n        └───────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Non-Technical User] -->|Describe Need| B[AI Agent]\n    B -->|Generate Code| C[Custom Tool]\n    C --> D{Satisfactory?}\n    D -->|No| E[Provide Feedback]\n    E --> B\n    D -->|Yes| F[Use Tool]\n    F --> G[Even Fix Bugs]\n    G --> B",
   "code_example": "# Example: Sales team member creates custom dashboard\n\n# User prompt:\n\"Create a dashboard that pulls our Salesforce pipeline data\nand shows weekly trends with a chart comparing to quota\"\n\n# Agent generates:\n# - Python script for Salesforce API integration\n# - Data processing for weekly aggregation\n# - Simple web dashboard with Chart.js\n# - Deployment configuration\n\n# User iterates:\n\"Add a filter for my territory only\"\n\"Make the quota line red\"\n\"Send me a Slack notification when pipeline drops 20%\"\n\n# Real example from Anthropic:\n# Communications team member shipping bug fixes to claude.ai",
   "when_to_use": {
-    "en": ["Domain experts need custom tools", "Business users want automation", "Simple bug fixes by non-engineers", "Rapid prototyping of internal tools"],
-    "ko": ["도메인 전문가가 맞춤 도구 필요", "비즈니스 사용자가 자동화 원함", "비엔지니어의 간단한 버그 수정", "내부 도구의 빠른 프로토타이핑"]
+    "en": [
+      "Domain experts need custom tools but lack programming expertise",
+      "Iterative refinement with quick results and user feedback",
+      "Hiding technical complexity while maintaining capability",
+      "Approval workflows for destructive operations to build trust with non-technical users"
+    ],
+    "ko": [
+      "도메인 전문가가 맞춤 도구가 필요하지만 프로그래밍 전문 지식 부족",
+      "빠른 결과와 사용자 피드백을 통한 반복적 개선",
+      "기능을 유지하면서 기술적 복잡성 은닉",
+      "비기술 사용자의 신뢰 구축을 위한 파괴적 작업 승인 워크플로우"
+    ]
   },
   "pros": {
-    "en": ["Domain experts build own tools", "Reduces engineering bottlenecks", "Faster iteration on business needs", "Enables citizen development"],
-    "ko": ["도메인 전문가가 자체 도구 구축", "엔지니어링 병목 감소", "비즈니스 요구에 빠른 반복", "시민 개발 가능"]
+    "en": [
+      "Enables domain experts to build their own tools",
+      "Reduces engineering bottlenecks",
+      "Creates learning feedback loops where users develop technical intuition through exposure"
+    ],
+    "ko": [
+      "도메인 전문가가 자체 도구 구축 가능",
+      "엔지니어링 병목 감소",
+      "노출을 통해 사용자가 기술적 직관을 개발하는 학습 피드백 루프 생성"
+    ]
   },
   "cons": {
-    "en": ["Quality and security concerns", "May create unmaintainable code", "Support burden on engineering", "Not suitable for complex systems"],
-    "ko": ["품질 및 보안 우려", "유지보수 불가능한 코드 생성 가능", "엔지니어링의 지원 부담", "복잡한 시스템에 적합하지 않음"]
+    "en": [
+      "Generated code may have reliability issues that non-technical users cannot detect",
+      "Production deployment remains challenging",
+      "Quality and security require guardrails rather than training"
+    ],
+    "ko": [
+      "생성된 코드에 비기술 사용자가 감지할 수 없는 신뢰성 문제 가능",
+      "프로덕션 배포는 여전히 어려움",
+      "품질과 보안은 교육이 아닌 가드레일 필요"
+    ]
   },
-  "tags": ["no-code", "low-code", "citizen-developer", "tool-creation", "business-users", "automation"]
+  "tags": ["no-code", "low-code", "citizen-developer", "tool-creation", "business-users", "automation", "custom-software"]
 }

--- a/src/data/patterns/episodic-memory-retrieval-injection.json
+++ b/src/data/patterns/episodic-memory-retrieval-injection.json
@@ -6,27 +6,49 @@
   "status": "validated-in-production",
   "original_url": "https://forum.cursor.com/t/agentic-memory-management-for-cursor/78021",
   "problem": {
-    "en": "Agents lack persistent memory across sessions, forgetting relevant past experiences and decisions.",
-    "ko": "에이전트가 세션 간 영구 메모리가 부족하여 관련 과거 경험과 결정을 잊어버립니다."
+    "en": "Stateless request handling causes agents to repeatedly rediscover decisions, constraints, and prior failures. Over multi-session workflows this leads to redundant work, inconsistent behavior, and shallow planning because each turn lacks durable historical context.",
+    "ko": "무상태 요청 처리로 인해 에이전트가 이전 결정, 제약 조건, 과거 실패를 반복적으로 재발견하게 됩니다. 다중 세션 워크플로우에서 각 턴에 지속적인 히스토리 컨텍스트가 없어 중복 작업, 일관되지 않은 동작, 피상적인 계획으로 이어집니다."
   },
   "solution": {
-    "en": "Store episodic memories in vector databases and retrieve relevant ones based on semantic similarity to current context.",
-    "ko": "벡터 데이터베이스에 일화적 메모리를 저장하고 현재 컨텍스트와의 의미적 유사성에 따라 관련 메모리를 검색합니다."
+    "en": "Add a **vector-backed episodic memory store**:\n\n1. After every episode, write a short \"memory blob\" (event, outcome, rationale) to the DB.\n2. On new tasks, embed the prompt, retrieve top-k similar memories, and inject as *hints* in the context.\n3. Apply TTL or decay scoring to prune stale memories.\n\nDesign memory writes as structured records (decision, evidence, outcome, confidence) rather than raw transcripts. Structured memory reduces repetitive outputs and improves reasoning (ParamMem 2026). At retrieval time, filter by task scope and recency so injected memories improve reasoning quality instead of introducing retrieval noise. Episodic memory with self-reflection achieved 91% pass@1 on HumanEval vs 80% baseline (Reflexion, NeurIPS 2023).",
+    "ko": "**벡터 기반 일화적 메모리 저장소**를 추가합니다:\n\n1. 매 에피소드 후, 짧은 \"메모리 블롭\"(이벤트, 결과, 근거)을 DB에 기록합니다.\n2. 새 작업 시, 프롬프트를 임베딩하고 top-k 유사 메모리를 검색하여 컨텍스트에 *힌트*로 주입합니다.\n3. TTL 또는 감쇠 점수를 적용하여 오래된 메모리를 정리합니다.\n\n메모리 기록은 원시 트랜스크립트가 아닌 구조화된 레코드(결정, 근거, 결과, 신뢰도)로 설계합니다. 구조화된 메모리는 반복적 출력을 줄이고 추론을 개선합니다(ParamMem 2026). 검색 시, 작업 범위와 최신성으로 필터링하여 주입된 메모리가 검색 노이즈를 도입하는 대신 추론 품질을 향상시킵니다. 자기 성찰이 포함된 일화적 메모리는 HumanEval에서 기준선 80% 대비 91% pass@1을 달성했습니다(Reflexion, NeurIPS 2023)."
   },
   "ascii_diagram": "┌─────────────┐\n│   Query     │\n└──────┬──────┘\n       │ embed\n┌──────▼──────┐\n│  Vector     │\n│  Embed      │\n└──────┬──────┘\n       │ search\n┌──────▼──────┐\n│ Vector DB   │\n│ (memories)  │\n└──────┬──────┘\n       │ top-k\n┌──────▼──────┐\n│ Inject to   │\n│ Context     │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Current Query] --> B[Embed Query]\n    B --> C[(Vector Database)]\n    C --> D[Top K Similar Memories]\n    D --> E[Inject to Context]\n    E --> F[Enhanced Response]",
   "code_example": "# Store memory after task completion\nmemory = {\n    'task': 'Fixed auth bug in login.py',\n    'context': code_changes,\n    'outcome': 'success'\n}\nvector_db.upsert(embed(memory), memory)\n\n# Retrieve relevant memories\nquery = 'authentication error handling'\nrelevant = vector_db.query(embed(query), top_k=3)\ncontext.inject(relevant)",
   "when_to_use": {
-    "en": ["Long-running projects", "Personalized assistants", "Repetitive tasks"],
-    "ko": ["장기 프로젝트", "개인화된 어시스턴트", "반복 작업"]
+    "en": [
+      "Multi-session coding agents, support copilots, and long-running research workflows",
+      "Start with a small top-k and strict metadata filters (task, repo, owner, timestamp)",
+      "Add memory quality review jobs to remove low-value or contradictory memories",
+      "Track whether retrieved memories improved outcomes versus baseline"
+    ],
+    "ko": [
+      "다중 세션 코딩 에이전트, 지원 코파일럿, 장기 연구 워크플로우",
+      "작은 top-k와 엄격한 메타데이터 필터(작업, 저장소, 소유자, 타임스탬프)로 시작",
+      "저가치 또는 모순되는 메모리를 제거하는 메모리 품질 검토 작업 추가",
+      "검색된 메모리가 기준선 대비 결과를 개선했는지 추적"
+    ]
   },
   "pros": {
-    "en": ["Cross-session continuity", "Relevant context retrieval", "Learning effect"],
-    "ko": ["세션 간 연속성", "관련 맥락 검색", "학습 효과"]
+    "en": [
+      "Richer continuity across sessions",
+      "Fewer repeated mistakes"
+    ],
+    "ko": [
+      "세션 간 풍부한 연속성",
+      "반복적 실수 감소"
+    ]
   },
   "cons": {
-    "en": ["Vector DB management", "Retrieval quality variance", "Privacy concerns"],
-    "ko": ["벡터 DB 관리", "검색 품질 차이", "프라이버시 우려"]
+    "en": [
+      "Retrieval noise if memories aren't curated",
+      "Storage cost"
+    ],
+    "ko": [
+      "메모리가 관리되지 않으면 검색 노이즈 발생",
+      "스토리지 비용"
+    ]
   },
-  "tags": ["episodic-memory", "vector-db", "retrieval-augmented", "persistence"]
+  "tags": ["episodic-memory", "vector-db", "retrieval-augmented", "context-hint"]
 }

--- a/src/data/patterns/graph-of-thoughts.json
+++ b/src/data/patterns/graph-of-thoughts.json
@@ -6,27 +6,59 @@
   "status": "emerging",
   "original_url": "https://arxiv.org/abs/2308.09687",
   "problem": {
-    "en": "Tree structures cannot represent thought aggregation or cycles in reasoning processes.",
-    "ko": "트리 구조는 추론 과정에서 생각의 집계나 순환을 표현할 수 없습니다."
+    "en": "Linear reasoning approaches like Chain-of-Thought (CoT) and even tree-based methods like Tree-of-Thoughts (ToT) have limitations when dealing with problems that require complex interdependencies between reasoning steps. Many real-world problems involve reasoning paths that merge, split, and recombine in ways that don't fit neatly into linear or tree structures. These problems need a more flexible approach that can represent arbitrary relationships between thoughts.",
+    "ko": "Chain-of-Thought(CoT)와 같은 선형 추론 방식이나 Tree-of-Thoughts(ToT)와 같은 트리 기반 방법은 추론 단계 간 복잡한 상호 의존성이 필요한 문제에 한계가 있습니다. 많은 실제 문제는 선형 또는 트리 구조에 깔끔하게 맞지 않는 방식으로 병합, 분기, 재결합하는 추론 경로를 포함합니다. 이러한 문제에는 생각 간 임의의 관계를 표현할 수 있는 더 유연한 접근 방식이 필요합니다."
   },
   "solution": {
-    "en": "Model reasoning as a graph where thoughts can merge, aggregate, and form cycles for complex problem solving.",
-    "ko": "생각이 병합, 집계, 순환을 형성할 수 있는 그래프로 추론을 모델링하여 복잡한 문제를 해결합니다."
+    "en": "Graph of Thoughts (GoT) extends reasoning frameworks by representing the thought process as a directed graph. GoT provides a general framework that subsumes Chain-of-Thought (linear) and Tree-of-Thoughts (branching) as special cases, with aggregation as the key enabling operation.\n\nIn GoT:\n\n- **Nodes** represent individual thoughts or reasoning states\n- **Edges** represent transformations or reasoning steps between thoughts\n- **Multiple paths** can lead to and from each node\n- **Aggregation operations** can combine multiple thoughts\n- **Backtracking** allows revisiting and refining previous thoughts\n\nThis enables operations like:\n1. **Branching**: Generate multiple thoughts from one\n2. **Aggregation**: Combine insights from multiple reasoning paths\n3. **Refinement**: Improve thoughts based on later insights\n4. **Looping**: Revisit and refine thoughts iteratively",
+    "ko": "Graph of Thoughts(GoT)는 사고 과정을 방향 그래프로 표현하여 추론 프레임워크를 확장합니다. GoT는 Chain-of-Thought(선형)와 Tree-of-Thoughts(분기)를 특수 케이스로 포함하는 일반 프레임워크를 제공하며, 집계가 핵심 연산입니다.\n\nGoT에서:\n\n- **노드**는 개별 생각 또는 추론 상태를 나타냅니다\n- **엣지**는 생각 간 변환 또는 추론 단계를 나타냅니다\n- **다중 경로**가 각 노드로 이어지거나 각 노드에서 나올 수 있습니다\n- **집계 연산**이 여러 생각을 결합할 수 있습니다\n- **백트래킹**으로 이전 생각을 재방문하고 개선할 수 있습니다\n\n이를 통해 다음 연산이 가능합니다:\n1. **분기**: 하나의 생각에서 여러 생각 생성\n2. **집계**: 여러 추론 경로의 통찰 결합\n3. **개선**: 후속 통찰을 기반으로 생각 개선\n4. **루프**: 생각을 반복적으로 재방문하고 개선"
   },
   "ascii_diagram": "      ┌───┐\n      │ A │\n      └─┬─┘\n     ┌──┴──┐\n     ▼     ▼\n   ┌───┐ ┌───┐\n   │ B │ │ C │\n   └─┬─┘ └─┬─┘\n     │     │\n     └──┬──┘ (merge)\n        ▼\n      ┌───┐\n      │ D │\n      └─┬─┘\n        │\n        ▼ (may cycle back)",
   "mermaid_diagram": "flowchart TD\n    A[Thought A] --> B[Thought B]\n    A --> C[Thought C]\n    B --> D[Merge D]\n    C --> D\n    D -->|Refine| A",
   "code_example": "graph = ThoughtGraph()\ngraph.add_node('A', initial_thought)\ngraph.branch('A', ['B', 'C'])\ngraph.merge(['B', 'C'], 'D')\nif needs_refinement(graph.get('D')):\n    graph.add_edge('D', 'A')  # cycle back",
   "when_to_use": {
-    "en": ["Complex problem solving", "Multi-perspective integration", "Iterative reasoning"],
-    "ko": ["복잡한 문제 해결", "다중 관점 통합", "반복적 추론"]
+    "en": [
+      "Complex problems with interdependent reasoning steps that need merging",
+      "Problems where early decisions may need revision based on later insights",
+      "Multi-perspective integration requiring aggregation of reasoning paths",
+      "Cases where LangGraph-like workflows with cycles and backtracking are beneficial"
+    ],
+    "ko": [
+      "병합이 필요한 상호 의존적 추론 단계가 있는 복잡한 문제",
+      "후속 통찰에 따라 초기 결정을 수정해야 할 수 있는 문제",
+      "추론 경로의 집계가 필요한 다중 관점 통합",
+      "순환과 백트래킹이 포함된 LangGraph 유사 워크플로우가 유용한 경우"
+    ]
   },
   "pros": {
-    "en": ["Flexible reasoning structure", "Thought aggregation possible", "Supports cyclic reasoning"],
-    "ko": ["유연한 추론 구조", "생각 집계 가능", "순환 추론 지원"]
+    "en": [
+      "Handles complex problems with interdependent reasoning steps",
+      "Can discover non-obvious connections between ideas",
+      "Supports iterative refinement and backtracking",
+      "More expressive than linear or tree-based approaches"
+    ],
+    "ko": [
+      "상호 의존적 추론 단계가 있는 복잡한 문제 처리",
+      "아이디어 간 비명시적 연결 발견 가능",
+      "반복적 개선과 백트래킹 지원",
+      "선형 또는 트리 기반 접근 방식보다 높은 표현력"
+    ]
   },
   "cons": {
-    "en": ["High implementation complexity", "Difficult to track reasoning paths"],
-    "ko": ["구현 복잡도 높음", "추론 경로 추적 어려움"]
+    "en": [
+      "Significantly higher computational cost (5-20x vs. linear reasoning)",
+      "Complex to implement and debug",
+      "May generate many redundant thoughts",
+      "Requires sophisticated scoring and path-finding algorithms",
+      "Can be overkill for simple problems"
+    ],
+    "ko": [
+      "현저히 높은 계산 비용 (선형 추론 대비 5-20배)",
+      "구현 및 디버깅 복잡",
+      "많은 중복 생각 생성 가능",
+      "정교한 점수화 및 경로 탐색 알고리즘 필요",
+      "단순한 문제에는 과도할 수 있음"
+    ]
   },
-  "tags": ["reasoning", "graph-based", "problem-solving", "aggregation"]
+  "tags": ["reasoning", "graph-based", "problem-solving", "thought-exploration", "backtracking", "aggregation"]
 }

--- a/src/data/patterns/iterative-multi-agent-brainstorming.json
+++ b/src/data/patterns/iterative-multi-agent-brainstorming.json
@@ -6,27 +6,53 @@
   "status": "experimental-but-awesome",
   "original_url": "https://www.nibzard.com/claude-code",
   "problem": {
-    "en": "A single AI agent instance might get stuck in a local optimum or fail to explore a diverse range of solutions for complex problems or creative ideation.",
-    "ko": "단일 AI 에이전트 인스턴스는 복잡한 문제나 창의적 아이디어 도출에서 지역 최적점에 갇히거나 다양한 솔루션 범위를 탐색하지 못할 수 있습니다."
+    "en": "For complex problems or creative ideation, a single AI agent instance might get stuck in a local optimum or fail to explore a diverse range of solutions. Generating a breadth of ideas can be challenging for a sequential, monolithic process.",
+    "ko": "복잡한 문제나 창의적 아이디어 도출에서 단일 AI 에이전트 인스턴스는 지역 최적점에 갇히거나 다양한 솔루션 범위를 탐색하지 못할 수 있습니다. 순차적이고 단일한 프로세스로는 폭넓은 아이디어를 생성하는 것이 어려울 수 있습니다."
   },
   "solution": {
-    "en": "Spawn multiple independent agent instances with the same task or varied perspectives, work in parallel, then synthesize outputs through a coordinator or human review.",
-    "ko": "동일한 작업이나 다양한 관점으로 여러 독립적인 에이전트 인스턴스를 생성하고, 병렬로 작업한 다음, 코디네이터나 인간 검토를 통해 출력을 종합합니다."
+    "en": "Employ a multi-agent approach for brainstorming and idea generation. This involves:\n1. Defining a core problem or task.\n2. Spawning multiple independent (or semi-independent) AI agent instances.\n3. Assigning each agent the same initial task or slightly varied perspectives on the task.\n4. Allowing each agent to work in parallel to generate ideas, solutions, or approaches.\n5. Collecting the outputs from all agents.\n6. Optionally, a coordinating agent or a human user can then synthesize these diverse outputs, identify common themes, or select the most promising ideas for further development.\n\nThis pattern leverages parallelism to explore a wider solution space and can lead to more creative or robust outcomes than a single agent might produce alone.",
+    "ko": "브레인스토밍과 아이디어 생성을 위한 다중 에이전트 접근 방식을 사용합니다. 다음을 포함합니다:\n1. 핵심 문제 또는 작업을 정의합니다.\n2. 여러 독립적(또는 반독립적) AI 에이전트 인스턴스를 생성합니다.\n3. 각 에이전트에 동일한 초기 작업 또는 약간 다른 관점을 할당합니다.\n4. 각 에이전트가 병렬로 아이디어, 솔루션, 접근 방식을 생성하도록 합니다.\n5. 모든 에이전트의 출력을 수집합니다.\n6. 선택적으로 조정 에이전트 또는 인간 사용자가 다양한 출력을 종합하고, 공통 주제를 식별하거나, 추가 개발을 위한 가장 유망한 아이디어를 선택합니다.\n\n이 패턴은 병렬성을 활용하여 더 넓은 솔루션 공간을 탐색하며, 단일 에이전트보다 더 창의적이거나 견고한 결과를 도출할 수 있습니다."
   },
   "ascii_diagram": "┌─────────────────┐\n│  Core Problem   │\n└────────┬────────┘\n    ┌────┼────┐\n    ▼    ▼    ▼\n┌────┐┌────┐┌────┐\n│Agt1││Agt2││Agt3│\n│PerA││PerB││PerC│\n└──┬─┘└──┬─┘└──┬─┘\n   │     │     │\n   ▼     ▼     ▼\n┌────┐┌────┐┌────┐\n│Sol1││Sol2││Sol3│\n└──┬─┘└──┬─┘└──┬─┘\n   └─────┼─────┘\n         ▼\n┌─────────────────┐\n│   Coordinator   │\n│    Synthesize   │\n└─────────────────┘",
-  "mermaid_diagram": "flowchart TD\n    A[Core Problem/Task] --> B[Agent 1: Perspective A]\n    A --> C[Agent 2: Perspective B]\n    A --> D[Agent 3: Perspective C]\n    B --> E[Solution Set 1]\n    C --> F[Solution Set 2]\n    D --> G[Solution Set 3]\n    E --> H[Coordinator/Human]\n    F --> H\n    G --> H\n    H --> I[Synthesized Solutions]",
+  "mermaid_diagram": "flowchart TD\n    A[Core Problem/Task] --> B[Agent 1: Perspective A]\n    A --> C[Agent 2: Perspective B]\n    A --> D[Agent 3: Perspective C]\n    B --> E[Solution Set 1]\n    C --> F[Solution Set 2]\n    D --> G[Solution Set 3]\n    E --> H[Coordinator/Human]\n    F --> H\n    G --> H\n    H --> I[Synthesized Solutions]\n    H --> J[Common Themes]\n    H --> K[Best Ideas Selected]",
   "code_example": "# Example: Parallel brainstorming with Claude Code\n# \"Use 3 parallel agents to brainstorm ideas for \n#  how to clean up @services/aggregator/feed_service.cpp\"\n\nasync def parallel_brainstorm(task, num_agents=3):\n    perspectives = [\n        'Focus on performance',\n        'Focus on readability',\n        'Focus on maintainability'\n    ]\n    \n    solutions = await asyncio.gather(*[\n        spawn_agent(task, perspective)\n        for perspective in perspectives[:num_agents]\n    ])\n    \n    return synthesize(solutions)",
   "when_to_use": {
-    "en": ["Complex problem exploration", "Creative ideation", "Architecture decisions needing diverse views"],
-    "ko": ["복잡한 문제 탐색", "창의적 아이디어 도출", "다양한 관점이 필요한 아키텍처 결정"]
+    "en": [
+      "When you need diverse perspectives or want to avoid local optimum trapping",
+      "Assign distinct roles or perspectives to each agent (e.g., critic, optimist, technical realist)",
+      "Limit to 2-4 agents for manageable coordination; more than 6 adds exponential overhead",
+      "Use a coordinating agent or human to synthesize and deduplicate outputs"
+    ],
+    "ko": [
+      "다양한 관점이 필요하거나 지역 최적점 함정을 피하고 싶을 때",
+      "각 에이전트에 고유한 역할이나 관점 할당 (예: 비평가, 낙관론자, 기술 현실주의자)",
+      "관리 가능한 조정을 위해 2-4개 에이전트로 제한; 6개 이상은 기하급수적 오버헤드 추가",
+      "조정 에이전트 또는 인간을 활용하여 출력 종합 및 중복 제거"
+    ]
   },
   "pros": {
-    "en": ["Wider solution space exploration", "Diverse perspectives", "Can lead to creative breakthroughs"],
-    "ko": ["더 넓은 솔루션 공간 탐색", "다양한 관점", "창의적 돌파구로 이어질 수 있음"]
+    "en": [
+      "Explores wider solution space",
+      "Reduces local optimum trapping",
+      "Enables diverse perspective exploration"
+    ],
+    "ko": [
+      "더 넓은 솔루션 공간 탐색",
+      "지역 최적점 함정 감소",
+      "다양한 관점 탐색 가능"
+    ]
   },
   "cons": {
-    "en": ["Higher token costs (multiple agents)", "Requires synthesis step", "May produce conflicting ideas"],
-    "ko": ["높은 토큰 비용 (다중 에이전트)", "종합 단계 필요", "상충하는 아이디어 생성 가능"]
+    "en": [
+      "Adds orchestration complexity",
+      "Coordination overhead increases with agent count",
+      "Requires synthesis mechanisms"
+    ],
+    "ko": [
+      "오케스트레이션 복잡성 증가",
+      "에이전트 수에 따라 조정 오버헤드 증가",
+      "종합 메커니즘 필요"
+    ]
   },
-  "tags": ["multi-agent", "brainstorming", "parallel-processing", "idea-generation", "collaborative-ideation"]
+  "tags": ["multi-agent", "brainstorming", "parallel processing", "idea generation", "sub-agents", "collaborative ideation"]
 }

--- a/src/data/patterns/multi-model-orchestration-for-complex-edits.json
+++ b/src/data/patterns/multi-model-orchestration-for-complex-edits.json
@@ -6,27 +6,51 @@
   "status": "validated-in-production",
   "original_url": "https://www.youtube.com/watch?v=BGgsoIgbT_Y",
   "problem": {
-    "en": "A single large language model may not be optimally suited for all sub-tasks in complex operations like multi-file code editing. Tasks like context retrieval, code generation, and edit application have different requirements.",
-    "ko": "단일 대형 언어 모델은 다중 파일 코드 편집과 같은 복잡한 작업의 모든 하위 작업에 최적으로 적합하지 않을 수 있습니다. 컨텍스트 검색, 코드 생성, 편집 적용과 같은 작업은 다른 요구사항을 가집니다."
+    "en": "A single large language model, even if powerful, may not be optimally suited for all sub-tasks involved in a complex operation like multi-file code editing. Tasks such as understanding broad context, generating precise code, and applying edits might benefit from specialized model capabilities.",
+    "ko": "단일 대형 언어 모델은 아무리 강력하더라도 다중 파일 코드 편집과 같은 복잡한 작업에 관련된 모든 하위 작업에 최적으로 적합하지 않을 수 있습니다. 넓은 컨텍스트 이해, 정밀한 코드 생성, 편집 적용과 같은 작업은 전문화된 모델 기능의 혜택을 받을 수 있습니다."
   },
   "solution": {
-    "en": "Employ a pipeline of multiple specialized models: retrieval model for context gathering, large generation model for code modifications, custom models for applying edits accurately.",
-    "ko": "여러 전문 모델의 파이프라인을 사용합니다: 컨텍스트 수집을 위한 검색 모델, 코드 수정을 위한 대형 생성 모델, 정확한 편집 적용을 위한 사용자 정의 모델."
+    "en": "Employ a pipeline or orchestration of multiple AI models, each specialized for different parts of a complex task. Different models excel at different cognitive tasks—specialization beats generalization. For code editing, this could involve:\n\n1. A **retrieval model** to gather relevant context from the codebase.\n2. A **large, intelligent generation model** (e.g., Claude 3.5 Sonnet) to understand the user's intent and generate the primary code modifications based on the retrieved context.\n3. Potentially other **custom or smaller models** to assist in applying these generated edits accurately across multiple files or performing fine-grained adjustments.\n\nPass only distilled conclusions between models, not full conversation histories. This reduces token costs and maintains clean phase boundaries. This approach leverages the strengths of different models in a coordinated fashion to achieve a more robust and effective outcome for complex operations than a single model might achieve alone.",
+    "ko": "복잡한 작업의 각 부분에 전문화된 여러 AI 모델의 파이프라인 또는 오케스트레이션을 사용합니다. 각 모델은 서로 다른 인지 작업에서 뛰어나며, 전문화가 범용화를 능가합니다. 코드 편집의 경우 다음을 포함할 수 있습니다:\n\n1. 코드베이스에서 관련 컨텍스트를 수집하는 **검색 모델**.\n2. 사용자의 의도를 이해하고 검색된 컨텍스트를 기반으로 주요 코드 수정을 생성하는 **대형 지능형 생성 모델** (예: Claude 3.5 Sonnet).\n3. 생성된 편집을 여러 파일에 정확하게 적용하거나 세밀한 조정을 수행하는 **사용자 정의 또는 소형 모델**.\n\n모델 간에는 전체 대화 기록이 아닌 정제된 결론만 전달합니다. 이를 통해 토큰 비용을 절감하고 깔끔한 단계 경계를 유지합니다."
   },
   "ascii_diagram": "┌─────────────────┐\n│  User Request   │\n│ Multi-File Edit │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ Retrieval Model │\n│ Gather Context  │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ Generation Model│\n│ (Claude Sonnet) │\n│ Generate Edits  │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│Application Model│\n│ Apply Across    │\n│    Files        │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ Edited Codebase │\n└─────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[User Request: Multi-File Edit] --> B[Retrieval Model: Gather Context]\n    B --> C[Main Generation Model: Generate Edits]\n    C --> D[Edit Application Model: Apply Edits Across Files]\n    D --> E[Edited Codebase]",
   "code_example": "class MultiModelOrchestrator:\n    def __init__(self):\n        self.retriever = RetrievalModel()  # Fast, specialized\n        self.generator = ClaudeSonnet()     # Intelligent, general\n        self.applier = EditApplicationModel()  # Precise, focused\n    \n    def process_edit_request(self, request):\n        # Phase 1: Retrieve relevant context\n        context = self.retriever.gather_context(request)\n        \n        # Phase 2: Generate edits with main model\n        edits = self.generator.generate_edits(request, context)\n        \n        # Phase 3: Apply edits precisely\n        result = self.applier.apply_edits(edits)\n        \n        return result",
   "when_to_use": {
-    "en": ["Multi-file code editing", "Complex codebase modifications", "Tasks needing specialized capabilities"],
-    "ko": ["다중 파일 코드 편집", "복잡한 코드베이스 수정", "전문 기능이 필요한 작업"]
+    "en": [
+      "When tasks need explicit control flow between planning, execution, and fallback",
+      "Start with one high-volume workflow before applying it across all agent lanes",
+      "Define ownership for each phase so failures can be routed and recovered quickly",
+      "Pass only distilled conclusions between model phases, not full conversation histories"
+    ],
+    "ko": [
+      "계획, 실행, 폴백 간 명시적 제어 흐름이 필요한 작업",
+      "모든 에이전트 레인에 적용하기 전에 하나의 고빈도 워크플로우부터 시작",
+      "실패를 빠르게 라우팅하고 복구할 수 있도록 각 단계의 소유권 정의",
+      "모델 단계 간에 전체 대화 기록이 아닌 정제된 결론만 전달"
+    ]
   },
   "pros": {
-    "en": ["Leverages specialized model strengths", "More robust outcomes", "Efficient resource usage"],
-    "ko": ["전문 모델 강점 활용", "더 견고한 결과", "효율적인 자원 사용"]
+    "en": [
+      "Improves coordination across multi-step workflows",
+      "Reduces hidden control flow",
+      "Enables cost optimization through right-sized model selection"
+    ],
+    "ko": [
+      "다단계 워크플로우 간 조정 개선",
+      "숨겨진 제어 흐름 감소",
+      "적절한 크기의 모델 선택을 통한 비용 최적화 가능"
+    ]
   },
   "cons": {
-    "en": ["Increased complexity", "Model coordination overhead", "Latency from multiple calls"],
-    "ko": ["복잡성 증가", "모델 조정 오버헤드", "다중 호출로 인한 지연"]
+    "en": [
+      "Adds orchestration complexity",
+      "More states to debug"
+    ],
+    "ko": [
+      "오케스트레이션 복잡성 증가",
+      "디버그해야 할 상태 증가"
+    ]
   },
-  "tags": ["multi-model", "code-generation", "code-editing", "retrieval", "pipeline"]
+  "tags": ["multi-model", "code-generation", "code-editing", "retrieval", "pipeline", "complex-tasks"]
 }

--- a/src/data/patterns/patch-steering-via-prompted-tool-selection.json
+++ b/src/data/patterns/patch-steering-via-prompted-tool-selection.json
@@ -6,27 +6,51 @@
   "status": "best-practice",
   "original_url": "https://www.youtube.com/watch?v=Xkwok_XXQgw",
   "problem": {
-    "en": "Agents with multiple patching tools may choose suboptimal ones without explicit guidance, leading to inconsistent results.",
-    "ko": "여러 패칭 도구가 있는 에이전트가 명시적 안내 없이 차선의 도구를 선택하여 일관되지 않은 결과를 초래할 수 있습니다."
+    "en": "Coding agents with access to multiple patching or refactoring tools (e.g., text-based apply_patch, AST-based refactoring, semantic migration) may choose suboptimal tools if not explicitly guided. This leads to unnecessary complexity, inconsistent results hampering reproducibility, and safety risks where text-based patching on refactoring tasks can break imports, miss references, or introduce syntax errors.",
+    "ko": "여러 패칭 또는 리팩토링 도구(예: 텍스트 기반 apply_patch, AST 기반 리팩토링, 시맨틱 마이그레이션)에 접근할 수 있는 코딩 에이전트가 명시적 안내 없이 차선의 도구를 선택할 수 있습니다. 이로 인해 불필요한 복잡성, 재현성을 저해하는 일관되지 않은 결과, 리팩토링 작업에서 텍스트 기반 패칭이 임포트를 깨뜨리거나 참조를 누락하거나 구문 오류를 도입하는 안전 위험이 발생합니다."
   },
   "solution": {
-    "en": "Steer the agent's tool selection through explicit natural language instructions in the prompt.",
-    "ko": "프롬프트에서 명시적 자연어 지시를 통해 에이전트의 도구 선택을 조정합니다."
+    "en": "**Steer** the agent's tool selection and patch approach through **explicit natural language instructions** in the prompt. Techniques include:\n\n**1. Direct Tool Invocation**\n- Prepend: \"Use the `apply_patch` tool to insert a new function `validate_input` in `auth_service.py`.\"\n\n**2. Tool Usage Teaching**\n- Provide a mini-manual in the context describing the tool's input schema and when to use it.\n\n**3. Implicit Shorthands**\n- Introduce domain-specific abbreviations that map to specific tools under the hood.\n\n**4. Reason-Encouraging Phrases**\n- Add: \"Think about type safety before choosing a patch tool.\" to promote deeper reasoning.\n\n**5. Negative Constraints**\n- Specify what NOT to use: \"Do NOT use text-based patching for function signature changes (will break imports).\" Explicit anti-patterns prevent unsafe tool selections more effectively than positive instructions alone.",
+    "ko": "프롬프트에서 **명시적 자연어 지시**를 통해 에이전트의 도구 선택과 패치 접근 방식을 **조정**합니다. 기법은 다음과 같습니다:\n\n**1. 직접 도구 호출**\n- \"`apply_patch` 도구를 사용하여 `auth_service.py`에 새 함수 `validate_input`을 삽입하세요.\"라고 앞에 추가합니다.\n\n**2. 도구 사용법 교육**\n- 컨텍스트에 도구의 입력 스키마와 사용 시기를 설명하는 미니 매뉴얼을 제공합니다.\n\n**3. 암시적 약어**\n- 내부적으로 특정 도구에 매핑되는 도메인별 약어를 도입합니다.\n\n**4. 추론 장려 문구**\n- \"패치 도구를 선택하기 전에 타입 안전성에 대해 생각하세요.\"를 추가하여 더 깊은 추론을 촉진합니다.\n\n**5. 부정 제약**\n- 사용하지 말아야 할 것을 명시합니다: \"함수 시그니처 변경에 텍스트 기반 패칭을 사용하지 마세요 (임포트가 깨집니다).\" 명시적 안티패턴은 긍정적 지시만으로는 달성하기 어려운 안전하지 않은 도구 선택을 더 효과적으로 방지합니다."
   },
   "ascii_diagram": "┌─────────────────────┐\n│ User: \"Refactor     │\n│ validation logic\"   │\n└──────────┬──────────┘\n           │\n┌──────────▼──────────┐\n│ Augmented Prompt:   │\n│ \"Use ASTRefactor    │\n│  for this task\"     │\n└──────────┬──────────┘\n           │\n┌──────────▼──────────┐\n│ Agent selects       │\n│ ASTRefactor tool    │\n└─────────────────────┘",
-  "mermaid_diagram": "flowchart TD\n    A[User: Refactor validation] --> B[Augmented Prompt]\n    B --> C[Please use ASTRefactor to update functions]\n    C --> D[Agent selects ASTRefactor]\n    D --> E[ASTRefactor patches code]",
+  "mermaid_diagram": "flowchart TD\n    A[User Prompt: \"Refactor validation logic\"] --> B[Augmented Prompt]\n    B --> C[\"Please use ASTRefactor to update function signatures\"]\n    C --> D[Agent selects ASTRefactor]\n    D --> E[ASTRefactorTool patches code]",
   "code_example": "# Prompt template for tool steering\nprompt_template = '''\nTask: {task_description}\nPreferred tool: {tool_name}\nUsage example: {tool_usage_snippet}\n\nIf {tool_name} fails, fallback to apply_patch.\n'''\n\n# Direct tool invocation in prompt\n\"Use the `apply_patch` tool to insert a new function `validate_input` in `auth_service.py`\"",
   "when_to_use": {
-    "en": ["Multi-tool agents", "Code refactoring tasks", "Consistent behavior requirements"],
-    "ko": ["멀티 도구 에이전트", "코드 리팩토링 작업", "일관된 동작 요구사항"]
+    "en": [
+      "Expose tool metadata (name, usage example, input schema, capabilities/limitations) in the agent's initialization context with use_when and avoid_when criteria",
+      "Create reusable prompt templates with placeholders for task description and preferred tool",
+      "Include fallback handling directives: specify fallback chains (semantic -> AST -> text)",
+      "When agents have access to multiple patching or refactoring tools"
+    ],
+    "ko": [
+      "에이전트 초기화 컨텍스트에 use_when과 avoid_when 기준이 포함된 도구 메타데이터(이름, 사용 예제, 입력 스키마, 기능/제한사항) 노출",
+      "작업 설명과 선호 도구를 위한 자리표시자가 있는 재사용 가능한 프롬프트 템플릿 생성",
+      "폴백 처리 지시문 포함: 폴백 체인 지정 (시맨틱 -> AST -> 텍스트)",
+      "에이전트가 여러 패칭 또는 리팩토링 도구에 접근할 수 있을 때"
+    ]
   },
   "pros": {
-    "en": ["Predictable behavior", "Higher code quality with semantic tools"],
-    "ko": ["예측 가능한 동작", "의미론적 도구로 더 높은 코드 품질"]
+    "en": [
+      "Predictable behavior: reduces variance in tool usage for the same task",
+      "Higher code quality: ensures the agent uses semantically safe tools over string-based replacements",
+      "Appropriate tool selection: guides agents to match tool capabilities to task requirements"
+    ],
+    "ko": [
+      "예측 가능한 동작: 동일 작업에 대한 도구 사용의 변동성 감소",
+      "높은 코드 품질: 에이전트가 문자열 기반 대체 대신 의미론적으로 안전한 도구를 사용하도록 보장",
+      "적절한 도구 선택: 도구 기능을 작업 요구사항에 맞추도록 에이전트를 안내"
+    ]
   },
   "cons": {
-    "en": ["Prompt length increases", "Template maintenance needed"],
-    "ko": ["프롬프트 길이 증가", "템플릿 유지보수 필요"]
+    "en": [
+      "Prompt length: excessive tool documentation in the prompt can consume valuable tokens",
+      "Maintenance: as new patching tools emerge, templates and tool registry need periodic updates"
+    ],
+    "ko": [
+      "프롬프트 길이: 프롬프트 내 과도한 도구 문서가 귀중한 토큰을 소비할 수 있음",
+      "유지보수: 새로운 패칭 도구가 등장하면 템플릿과 도구 레지스트리의 주기적 업데이트 필요"
+    ]
   },
   "tags": ["patching", "prompt-steering", "tool-selection", "coding-agent"]
 }

--- a/src/data/patterns/rlaif-reinforcement-learning-from-ai-feedback.json
+++ b/src/data/patterns/rlaif-reinforcement-learning-from-ai-feedback.json
@@ -6,27 +6,57 @@
   "status": "emerging",
   "original_url": "https://arxiv.org/abs/2212.08073",
   "problem": {
-    "en": "Traditional RLHF requires expensive human annotation ($1+ per label) which is slow and hard to scale.",
-    "ko": "전통적인 RLHF는 비용이 많이 드는 인간 주석(레이블당 $1+)이 필요하며 느리고 확장하기 어렵습니다."
+    "en": "Traditional Reinforcement Learning from Human Feedback (RLHF) requires extensive human annotation for preference data, which is expensive (often $1+ per annotation), time-consuming, and difficult to scale. This creates a bottleneck in training aligned AI systems, especially when dealing with complex or specialized domains where human expertise is scarce or costly.",
+    "ko": "전통적인 인간 피드백 강화 학습(RLHF)은 선호도 데이터에 대한 광범위한 인간 주석이 필요하며, 이는 비용이 많이 들고(주석당 $1 이상), 시간이 오래 걸리며, 확장하기 어렵습니다. 이는 정렬된 AI 시스템 훈련에 병목 현상을 만들며, 특히 인간 전문 지식이 부족하거나 비용이 많이 드는 복잡하거나 전문적인 도메인에서 그렇습니다."
   },
   "solution": {
-    "en": "Use AI models to generate preference feedback and evaluation data, reducing costs to <$0.01 per annotation.",
-    "ko": "AI 모델을 사용하여 선호도 피드백과 평가 데이터를 생성하여 비용을 주석당 $0.01 미만으로 줄입니다."
+    "en": "RLAIF replaces human annotators with a supervisory AI model that generates preference labels, which train a reward model that optimizes the policy via PPO (or similar RL algorithms). The approach involves:\n\n1. **AI-Generated Critiques**: Use a language model to evaluate outputs based on a set of principles or constitution\n2. **Preference Data Generation**: Have the AI model compare pairs of responses and select the better one according to specified criteria\n3. **Synthetic Training Data**: Generate high-quality training examples using the AI's own capabilities\n4. **Constitutional Principles**: Guide the feedback process with explicit rules rather than implicit human preferences\n\nThis technique forms the foundation of Constitutional AI. Most production systems use hybrid approaches combining RLAIF (for scale) with RLHF (for quality validation).",
+    "ko": "RLAIF는 인간 주석자를 감독 AI 모델로 대체하여 선호도 레이블을 생성하고, 이를 통해 PPO(또는 유사한 RL 알고리즘)로 정책을 최적화하는 보상 모델을 훈련합니다. 접근 방식은 다음을 포함합니다:\n\n1. **AI 생성 비평**: 원칙 또는 헌법 세트를 기반으로 출력을 평가하는 언어 모델 사용\n2. **선호도 데이터 생성**: AI 모델이 응답 쌍을 비교하고 지정된 기준에 따라 더 나은 것을 선택\n3. **합성 훈련 데이터**: AI 자체의 능력을 사용하여 고품질 훈련 예제 생성\n4. **헌법적 원칙**: 암묵적인 인간 선호도가 아닌 명시적 규칙으로 피드백 과정 안내\n\n이 기법은 Constitutional AI의 기반을 형성합니다. 대부분의 프로덕션 시스템은 RLAIF(확장성용)와 RLHF(품질 검증용)를 결합한 하이브리드 접근 방식을 사용합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│  Response A │\n│  Response B │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│ AI Critic   │\n│ (with rules)│\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│ Preference  │\n│ A > B       │\n│ + Reasoning │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│  Train on   │\n│ AI feedback │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Generate Responses A, B] --> B[AI Critic Evaluates]\n    B --> C[Preference + Explanation]\n    C --> D[Train Reward Model]\n    D --> E[Use for RLHF]",
   "code_example": "class RLAIFAgent:\n    def generate_preference(self, prompt, response_a, response_b):\n        critique_prompt = f'''\n        Given these principles: {self.constitution}\n        \n        Which response is better for: \"{prompt}\"\n        Response A: {response_a}\n        Response B: {response_b}\n        \n        Choose and explain why.\n        '''\n        return self.critic_model.generate(critique_prompt)",
   "when_to_use": {
-    "en": ["Reward model training", "Alignment at scale", "Constitutional AI"],
-    "ko": ["보상 모델 훈련", "대규모 정렬", "헌법적 AI"]
+    "en": [
+      "Scalable feedback for alignment training beyond human annotation capacity",
+      "Starting with a well-aligned supervisory model capable of evaluating the target domain",
+      "Hybrid RLAIF/RLHF for critical applications where human validation is important",
+      "Constitutional principles for explicit control over evaluation criteria"
+    ],
+    "ko": [
+      "인간 주석 용량을 초과하는 정렬 훈련을 위한 확장 가능한 피드백",
+      "대상 도메인을 평가할 수 있는 잘 정렬된 감독 모델로 시작",
+      "인간 검증이 중요한 핵심 애플리케이션을 위한 하이브리드 RLAIF/RLHF",
+      "평가 기준에 대한 명시적 제어를 위한 헌법적 원칙"
+    ]
   },
   "pros": {
-    "en": ["100x cheaper than human feedback", "Scales with compute", "More consistent"],
-    "ko": ["인간 피드백보다 100배 저렴", "컴퓨팅으로 확장", "더 일관적"]
+    "en": [
+      "Cost efficiency: 100x cheaper than human feedback ($0.01 vs $1+)",
+      "Scalability: can generate unlimited feedback data without human bottlenecks",
+      "Consistency: AI feedback is more consistent than varying human annotators",
+      "Speed: near-instantaneous feedback generation"
+    ],
+    "ko": [
+      "비용 효율성: 인간 피드백보다 100배 저렴 ($0.01 vs $1+)",
+      "확장성: 인간 병목 없이 무제한 피드백 데이터 생성 가능",
+      "일관성: AI 피드백은 다양한 인간 주석자보다 더 일관적",
+      "속도: 거의 즉각적인 피드백 생성"
+    ]
   },
   "cons": {
-    "en": ["May amplify biases", "Limited novelty in feedback", "Principle design needed"],
-    "ko": ["편향 증폭 가능", "피드백의 제한된 새로움", "원칙 설계 필요"]
+    "en": [
+      "Bias amplification: may reinforce existing model biases",
+      "Alignment dependency: inherits alignment properties of the supervisory model",
+      "Chicken-and-egg problem: requires a capable supervisory model to train frontier models",
+      "Principle design: requires careful crafting of constitutional principles"
+    ],
+    "ko": [
+      "편향 증폭: 기존 모델 편향을 강화할 수 있음",
+      "정렬 의존성: 감독 모델의 정렬 속성을 상속",
+      "닭과 달걀 문제: 프론티어 모델 훈련에 유능한 감독 모델 필요",
+      "원칙 설계: 헌법적 원칙의 신중한 설계 필요"
+    ]
   },
-  "tags": ["rlhf", "rlaif", "constitutional-ai", "synthetic-data", "alignment"]
+  "tags": ["rlhf", "rlaif", "constitutional-ai", "synthetic-data", "feedback", "alignment", "evaluation"]
 }

--- a/src/data/patterns/subagent-compilation-checker.json
+++ b/src/data/patterns/subagent-compilation-checker.json
@@ -2,31 +2,51 @@
   "id": "subagent-compilation-checker",
   "title": "Subagent Compilation Checker",
   "title_ko": "서브에이전트 컴파일 검사기",
-  "category": "Tool Use & Environment",
+  "category": "Reliability & Eval",
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=Xkwok_XXQgw",
   "problem": {
-    "en": "Large coding tasks with multiple components blow up context length when main agent handles all compilation. Build logs in prompts are impractical and slow down inference.",
-    "ko": "여러 컴포넌트가 있는 대규모 코딩 작업은 메인 에이전트가 모든 컴파일을 처리할 때 컨텍스트 길이를 폭발시킵니다. 프롬프트의 빌드 로그는 비실용적이고 추론을 느리게 합니다."
+    "en": "Large coding tasks often involve multiple independent components (e.g., microservices, libraries). Having the main agent handle compilation and error checking for every component in-context:\n\n- **Blows Up Context Length:** Including entire build logs or bytecode in the prompt is impractical.\n- **Slows Down Inference:** Sending full build commands and parsing verbose output in-context uses excessive tokens.\n\nAdditionally, when the agent's single \"compile-and-run\" step fails, it's hard to pinpoint which submodule caused the error without a more granular approach.",
+    "ko": "대규모 코딩 작업은 종종 여러 독립적 컴포넌트(예: 마이크로서비스, 라이브러리)를 포함합니다. 메인 에이전트가 모든 컴포넌트의 컴파일과 오류 검사를 컨텍스트 내에서 처리하면:\n\n- **컨텍스트 길이 폭발:** 전체 빌드 로그나 바이트코드를 프롬프트에 포함하는 것은 비실용적입니다.\n- **추론 속도 저하:** 전체 빌드 명령을 전송하고 상세 출력을 컨텍스트 내에서 파싱하면 과도한 토큰을 사용합니다.\n\n또한, 에이전트의 단일 \"컴파일-실행\" 단계가 실패하면 더 세분화된 접근 방식 없이는 어떤 서브모듈이 오류를 유발했는지 파악하기 어렵습니다."
   },
   "solution": {
-    "en": "Spawn specialized Compilation Subagents to independently build and verify each module, reporting back only concise error summaries (file, line, error message) or artifact references.",
-    "ko": "각 모듈을 독립적으로 빌드하고 검증하는 전문 컴파일 서브에이전트를 생성하고, 간결한 오류 요약(파일, 라인, 오류 메시지) 또는 아티팩트 참조만 반환합니다."
+    "en": "Spawn **specialized \"Compilation Subagents\"** to independently build and verify each code submodule, reporting back only:\n\n**1. Error Summary:** File paths, line numbers, and error messages.\n**2. Binary Artifacts (if needed):** Reference IDs (e.g., paths to compiled object files) rather than raw binaries.\n\n**Workflow:**\n- **Main Agent Request:** \"Compile module `auth-service`.\"\n- **Spawn `CompileSubagent(auth-service)`**\n  - Subagent runs `mvn clean install` or `go build ./auth-service`.\n  - Returns a structured error list or location of compiled artifact.\n- **Main Agent:** Updates its context with the **concise error report** (e.g., `[{file: \"auth_controller.go\", line: 85, error: \"undefined: UserModel\"}]`).",
+    "ko": "각 코드 서브모듈을 독립적으로 빌드하고 검증하는 **전문 \"컴파일 서브에이전트\"**를 생성하여 다음만 보고합니다:\n\n**1. 오류 요약:** 파일 경로, 줄 번호, 오류 메시지.\n**2. 바이너리 아티팩트 (필요시):** 원시 바이너리가 아닌 참조 ID(예: 컴파일된 오브젝트 파일 경로).\n\n**워크플로우:**\n- **메인 에이전트 요청:** \"모듈 `auth-service`를 컴파일하라.\"\n- **`CompileSubagent(auth-service)` 생성**\n  - 서브에이전트가 `mvn clean install` 또는 `go build ./auth-service`를 실행합니다.\n  - 구조화된 오류 목록 또는 컴파일된 아티팩트 위치를 반환합니다.\n- **메인 에이전트:** **간결한 오류 보고서**(예: `[{file: \"auth_controller.go\", line: 85, error: \"undefined: UserModel\"}]`)로 컨텍스트를 업데이트합니다."
   },
   "ascii_diagram": "┌─────────────────┐\n│   Main Agent    │\n│ 'Compile auth'  │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│CompileSubagent  │\n│  (auth-service) │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ go build ./auth │\n└────────┬────────┘\n    ┌────┴────┐\n    ▼         ▼\n[Success] [Failure]\n    │         │\n    │    [{file, line, error}]\n    │         │\n    └────┬────┘\n         │\n┌────────▼────────┐\n│  Concise Report │\n│  to Main Agent  │\n└─────────────────┘",
   "mermaid_diagram": "sequenceDiagram\n    MainAgent->>CompileSubagent: Compile service A\n    CompileSubagent->>BuildEnv: go build ./serviceA\n    alt Build Success\n        CompileSubagent-->>MainAgent: {status: 'success', artifact: 'serviceA.bin'}\n    else Build Failure\n        CompileSubagent-->>MainAgent: [{file: 'fileA.go', line: 10, error: 'Syntax error'}]\n    end\n    MainAgent->>Context: Inject concise error summary",
   "code_example": "# Main agent spawns compilation subagent\nresult = spawn_subagent(\n    type='compile',\n    target='auth-service',\n    command='go build ./auth-service'\n)\n\n# Subagent returns structured report\n# Success: {status: 'success', artifact: 'auth.bin'}\n# Failure: [{file: 'auth.go', line: 85, error: 'undefined: UserModel'}]\n\n# Main agent sees only concise summary, not full build log",
   "when_to_use": {
-    "en": ["Multi-module projects", "Long build processes", "Parallel compilation needed"],
-    "ko": ["다중 모듈 프로젝트", "긴 빌드 프로세스", "병렬 컴파일 필요"]
+    "en": [
+      "Subagent as a lightweight container or process with appropriate runtime (e.g., JVM for Java, Node for JavaScript)",
+      "Integration in RL loop treating each subagent invocation as a tool call",
+      "Error-driven reward assigning negative reward proportional to error count"
+    ],
+    "ko": [
+      "적절한 런타임을 갖춘 경량 컨테이너 또는 프로세스로서의 서브에이전트 (예: Java용 JVM, JavaScript용 Node)",
+      "각 서브에이전트 호출을 도구 호출로 취급하는 RL 루프 통합",
+      "오류 수에 비례하는 음의 보상을 부여하는 오류 기반 보상"
+    ]
   },
   "pros": {
-    "en": ["Modular isolation", "Parallel builds possible", "Context length preserved"],
-    "ko": ["모듈식 격리", "병렬 빌드 가능", "컨텍스트 길이 보존"]
+    "en": [
+      "Modular isolation: main agent never needs to load entire build logs into context",
+      "Parallel builds: multiple subagents can compile different modules simultaneously, speeding up end-to-end workflow"
+    ],
+    "ko": [
+      "모듈식 격리: 메인 에이전트가 전체 빌드 로그를 컨텍스트에 로드할 필요 없음",
+      "병렬 빌드: 여러 서브에이전트가 동시에 다른 모듈을 컴파일하여 종단 간 워크플로우 가속"
+    ]
   },
   "cons": {
-    "en": ["Infrastructure overhead for build environments", "Subagent synchronization needed"],
-    "ko": ["빌드 환경을 위한 인프라 오버헤드", "서브에이전트 동기화 필요"]
+    "en": [
+      "Infrastructure overhead: requires mechanism to spin up and tear down multiple build environments",
+      "Subagent synchronization: if one module depends on another's build artifact, coordination policies must ensure correct build order"
+    ],
+    "ko": [
+      "인프라 오버헤드: 여러 빌드 환경을 생성하고 해제하는 메커니즘 필요",
+      "서브에이전트 동기화: 한 모듈이 다른 모듈의 빌드 아티팩트에 의존하면 올바른 빌드 순서를 보장하는 조정 정책 필요"
+    ]
   },
   "tags": ["subagent", "compilation", "modularity", "error-isolation"]
 }

--- a/src/data/patterns/tool-use-incentivization-via-reward-shaping.json
+++ b/src/data/patterns/tool-use-incentivization-via-reward-shaping.json
@@ -6,27 +6,51 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=Xkwok_XXQgw",
   "problem": {
-    "en": "Coding agents often underutilize specialized tools, defaulting to thinking tokens instead of invoking compilers, linters, or test runners.",
-    "ko": "코딩 에이전트가 컴파일러, 린터, 테스트 러너를 호출하는 대신 생각 토큰을 기본으로 사용하여 전문 도구를 충분히 활용하지 못합니다."
+    "en": "Coding agents often underutilize specialized tools (e.g., compilers, linters, test runners) when left to optimize only for final task success. They default to \"thinking\" tokens—generating internal chain-of-thought—instead of invoking external tools, which can slow down development and lead to suboptimal code outputs. Models like R1 use their think tokens almost exclusively rather than calling tools unless explicitly rewarded for tool use. Without intermediate incentives, the agent has no incentive to write code, compile, or run tests until the very end. Sparse final rewards provide insufficient signal for learning optimal tool-use patterns across multi-step episodes.",
+    "ko": "코딩 에이전트가 최종 작업 성공만을 최적화하도록 두면 전문 도구(예: 컴파일러, 린터, 테스트 러너)를 충분히 활용하지 못합니다. 외부 도구를 호출하는 대신 내부 사고 연쇄를 생성하는 \"생각\" 토큰을 기본으로 사용하여 개발 속도가 느려지고 최적이 아닌 코드 출력으로 이어집니다. R1과 같은 모델은 도구 사용에 대한 명시적 보상이 없으면 생각 토큰만 거의 독점적으로 사용합니다. 중간 인센티브가 없으면 에이전트는 맨 마지막까지 코드를 작성하거나 컴파일하거나 테스트를 실행할 동기가 없습니다. 희소한 최종 보상은 다단계 에피소드에서 최적의 도구 사용 패턴을 학습하는 데 불충분한 신호를 제공합니다."
   },
   "solution": {
-    "en": "Provide dense, shaped rewards for every intermediate tool invocation that contributes toward final code correctness.",
-    "ko": "최종 코드 정확성에 기여하는 모든 중간 도구 호출에 대해 밀도 있는 보상을 제공합니다."
+    "en": "Provide **dense, shaped rewards** for every intermediate tool invocation that contributes toward final code correctness. Key components:\n\n**1. Define Tool-Specific Reward Signals**\n- **Compile Reward:** +1 if code compiles without errors.\n- **Lint Reward:** +0.5 if linter returns zero issues.\n- **Test Reward:** +2 if test suite passes a new test case.\n- **Documentation Reward:** +0.2 for adding or correcting docstrings.\n- **Efficiency Reward:** +0.1 for parallelizing independent tool calls; -0.05 for redundant invocations.\n- **Format Reward:** +0.2 for proper tool invocation schema compliance.\n\n**2. Episode-Level Aggregation**\n- Sum intermediate rewards to form a cumulative \"coding progress\" score.\n- Combine with final reward (e.g., full test suite pass or PR merge) to guide policy updates.\n- Use turn-level credit assignment to attribute rewards correctly across multi-step tool sequences.\n\n**3. Policy Update Mechanism**\n- Use Proximal Policy Optimization (PPO), Advantage Actor-Critic (A2C), or GRPO with these shaped rewards.\n- During each RL rollout, track `(state, action, tool_result, local_reward)` tuples.\n\n```python\n# Pseudo-code: at each RL step, after tool call:\nif action == \"compile\":\n    local_reward = 1 if compile_success else -0.5\nelif action == \"run_tests\":\n    local_reward = 2 if new_tests_passed else 0\nelif action == \"parallel_tool_batch\":\n    local_reward = 0.1  # efficiency bonus\n\n# Check for redundant calls\nif is_redundant_call(action, history):\n    local_reward -= 0.05\n\ntrajectory.append((state, action, tool_output, local_reward))\n```",
+    "ko": "최종 코드 정확성에 기여하는 모든 중간 도구 호출에 대해 **밀도 있는 형성 보상**을 제공합니다. 주요 구성 요소:\n\n**1. 도구별 보상 신호 정의**\n- **컴파일 보상:** 코드가 오류 없이 컴파일되면 +1.\n- **린트 보상:** 린터가 문제 없음을 반환하면 +0.5.\n- **테스트 보상:** 테스트 스위트가 새 테스트 케이스를 통과하면 +2.\n- **문서화 보상:** 독스트링 추가 또는 수정 시 +0.2.\n- **효율성 보상:** 독립적 도구 호출 병렬화 시 +0.1, 중복 호출 시 -0.05.\n- **형식 보상:** 적절한 도구 호출 스키마 준수 시 +0.2.\n\n**2. 에피소드 수준 집계**\n- 중간 보상을 합산하여 누적 \"코딩 진행\" 점수를 형성합니다.\n- 최종 보상(예: 전체 테스트 스위트 통과 또는 PR 머지)과 결합하여 정책 업데이트를 안내합니다.\n- 턴 수준 크레딧 할당을 사용하여 다단계 도구 시퀀스에서 보상을 올바르게 귀속합니다.\n\n**3. 정책 업데이트 메커니즘**\n- PPO(Proximal Policy Optimization), A2C(Advantage Actor-Critic), 또는 GRPO를 형성 보상과 함께 사용합니다.\n- 각 RL 롤아웃에서 `(상태, 행동, 도구_결과, 로컬_보상)` 튜플을 추적합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│   Agent     │\n│   Action    │\n└──────┬──────┘\n       │\n   ┌───┴───┐\n   ▼       ▼\n┌─────┐ ┌─────┐\n│Comp │ │Test │\n│+1.0 │ │+2.0 │\n└──┬──┘ └──┬──┘\n   └───┬───┘\n       ▼\n┌─────────────┐\n│ Cumulative  │\n│   Reward    │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Agent Action] --> B{Tool Type}\n    B -->|Compile| C[+1.0 if success]\n    B -->|Test| D[+2.0 if pass]\n    B -->|Lint| E[+0.5 if clean]\n    C & D & E --> F[Aggregate Reward]\n    F --> G[Policy Update]",
   "code_example": "if action == 'compile':\n    reward = 1.0 if compile_success else -0.5\nelif action == 'run_tests':\n    reward = 2.0 if new_tests_passed else 0\nelif action == 'lint':\n    reward = 0.5 if lint_clean else 0\ntrajectory.append((state, action, reward))",
   "when_to_use": {
-    "en": ["RL-based agent training", "Tool utilization improvement", "Coding agent development"],
-    "ko": ["RL 기반 에이전트 훈련", "도구 활용 개선", "코딩 에이전트 개발"]
+    "en": [
+      "Instrumentation: Wrap tool calls with functions that return a binary or graded success signal",
+      "Hyperparameter tuning to prevent overfitting to one tool",
+      "Curriculum design starting with simpler tasks to collect early positive signals",
+      "Multi-criteria grading with weighted combinations of correctness, format, tool-use quality, and efficiency",
+      "RLAIF for scalable, cost-effective reward signal generation"
+    ],
+    "ko": [
+      "도구 호출을 이진 또는 등급 성공 신호를 반환하는 함수로 래핑하는 계측",
+      "하나의 도구에 과적합하지 않도록 하이퍼파라미터 튜닝",
+      "초기 긍정 신호를 수집하기 위해 단순한 작업부터 시작하는 커리큘럼 설계",
+      "정확성, 형식, 도구 사용 품질, 효율성의 가중 조합을 사용한 다기준 평가",
+      "확장 가능하고 비용 효율적인 보상 신호 생성을 위한 RLAIF"
+    ]
   },
   "pros": {
-    "en": ["Denser feedback guiding step-by-step", "Encourages tool adoption"],
-    "ko": ["단계별 안내하는 밀도 높은 피드백", "도구 채택 장려"]
+    "en": [
+      "Denser feedback guiding the agent step by step, reducing reliance on sparse final success signals",
+      "Encourages the agent to learn how and when to invoke compilers and test runners"
+    ],
+    "ko": [
+      "에이전트를 단계별로 안내하는 밀도 높은 피드백으로 희소한 최종 성공 신호 의존도 감소",
+      "에이전트가 컴파일러와 테스트 러너를 언제 어떻게 호출하는지 학습하도록 장려"
+    ]
   },
   "cons": {
-    "en": ["Reward engineering overhead", "Potential overfitting to intermediate rewards"],
-    "ko": ["보상 설계 오버헤드", "중간 보상에 대한 과적합 가능성"]
+    "en": [
+      "Reward engineering overhead: requires careful design and maintenance of reward functions for each tool",
+      "Potential overfitting: the agent may game intermediate rewards (e.g., repeatedly running lint without changing code)"
+    ],
+    "ko": [
+      "보상 설계 오버헤드: 각 도구에 대한 보상 함수의 신중한 설계와 유지보수 필요",
+      "과적합 가능성: 에이전트가 중간 보상을 악용할 수 있음 (예: 코드 변경 없이 반복적으로 린트 실행)"
+    ]
   },
   "tags": ["tool-use", "reward-shaping", "coding-agent", "RL"]
 }

--- a/src/data/patterns/verbose-reasoning-transparency.json
+++ b/src/data/patterns/verbose-reasoning-transparency.json
@@ -6,27 +6,51 @@
   "status": "best-practice",
   "original_url": "https://www.nibzard.com/claude-code",
   "problem": {
-    "en": "Black-box agent outputs are hard to debug, verify, and trust without visibility into reasoning.",
-    "ko": "블랙박스 에이전트 출력은 추론에 대한 가시성 없이 디버깅, 검증, 신뢰하기 어렵습니다."
+    "en": "AI agents, especially those using complex models or multiple tools, can sometimes behave like \"black boxes.\" Users may not understand why an agent made a particular decision, chose a specific tool, or generated a certain output. This lack of transparency can hinder debugging, trust, and the ability to effectively guide the agent.",
+    "ko": "AI 에이전트, 특히 복잡한 모델이나 여러 도구를 사용하는 에이전트는 때때로 \"블랙박스\"처럼 동작할 수 있습니다. 사용자는 에이전트가 특정 결정을 내린 이유, 특정 도구를 선택한 이유, 또는 특정 출력을 생성한 이유를 이해하지 못할 수 있습니다. 이러한 투명성 부족은 디버깅, 신뢰, 그리고 에이전트를 효과적으로 안내하는 능력을 저해할 수 있습니다."
   },
   "solution": {
-    "en": "Expose detailed reasoning chains and decision steps for debugging, verification, and user understanding.",
-    "ko": "디버깅, 검증, 사용자 이해를 위해 상세한 추론 체인과 결정 단계를 노출합니다."
+    "en": "Implement a feature that allows users to inspect the agent's internal \"thought process\" or reasoning steps on demand. This could be triggered by a keybinding (e.g., `Ctrl+R` in Claude Code) or a command.\n\nWhen activated, the verbose output might reveal:\n\n- The agent's interpretation of the user's prompt.\n- Alternative actions or tools it considered.\n- The specific tool(s) it selected and why (if available).\n- Intermediate steps or sub-tasks it performed.\n- Confidence scores or internal states.\n- Raw outputs from tools before they are processed or summarized.\n\nThis transparency helps users understand the agent's decision-making process, identify issues if the agent is stuck or producing incorrect results, and learn how to prompt more effectively.",
+    "ko": "사용자가 에이전트의 내부 \"사고 과정\" 또는 추론 단계를 필요에 따라 검사할 수 있는 기능을 구현합니다. 이는 키바인딩(예: Claude Code의 `Ctrl+R`) 또는 명령어로 트리거할 수 있습니다.\n\n활성화되면 상세 출력은 다음을 보여줄 수 있습니다:\n\n- 사용자 프롬프트에 대한 에이전트의 해석\n- 고려한 대안 행동 또는 도구\n- 선택한 특정 도구와 그 이유 (가능한 경우)\n- 수행한 중간 단계 또는 하위 작업\n- 신뢰도 점수 또는 내부 상태\n- 도구의 원시 출력 (처리 또는 요약 전)\n\n이러한 투명성은 사용자가 에이전트의 의사 결정 과정을 이해하고, 에이전트가 막히거나 잘못된 결과를 생성할 때 문제를 식별하며, 더 효과적으로 프롬프트하는 방법을 학습하는 데 도움이 됩니다."
   },
   "ascii_diagram": "┌───────────────────────────┐\n│   Verbose Mode            │\n├───────────────────────────┤\n│ Step 1: Analyzing task... │\n│ Step 2: Found files...    │\n│ Step 3: Planning edits... │\n│ Step 4: Executing...      │\n│ Step 5: Verifying...      │\n│                           │\n│ [User can inspect each]   │\n└───────────────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Agent] -->|Log| B[Step 1: Analyze]\n    B -->|Log| C[Step 2: Search]\n    C -->|Log| D[Step 3: Plan]\n    D -->|Log| E[Step 4: Execute]\n    B & C & D & E --> F[User Inspection Panel]",
   "code_example": "class VerboseAgent:\n    def execute(self, task, verbose=True):\n        steps = []\n        \n        step = self.analyze(task)\n        if verbose: steps.append(f'Analyzing: {step}')\n        \n        files = self.search(step)\n        if verbose: steps.append(f'Found {len(files)} files')\n        \n        plan = self.plan(files)\n        if verbose: steps.append(f'Plan: {plan}')\n        \n        result = self.run(plan)\n        if verbose: steps.append(f'Result: {result}')\n        \n        return {'result': result, 'reasoning': steps}",
   "when_to_use": {
-    "en": ["Debugging sessions", "Trust building", "Learning/training purposes"],
-    "ko": ["디버깅 세션", "신뢰 구축", "학습/훈련 목적"]
+    "en": [
+      "Debugging agents that produce incorrect or unexpected outputs",
+      "Learning how to prompt more effectively by studying agent reasoning patterns",
+      "Building trust in high-stakes scenarios where understanding \"why\" matters",
+      "Complementing human-in-the-loop approval workflows with transparency"
+    ],
+    "ko": [
+      "잘못되거나 예상치 못한 출력을 생성하는 에이전트 디버깅",
+      "에이전트 추론 패턴을 연구하여 더 효과적인 프롬프트 방법 학습",
+      "\"왜\"를 이해하는 것이 중요한 고위험 시나리오에서 신뢰 구축",
+      "투명성으로 사람 개입 승인 워크플로우 보완"
+    ]
   },
   "pros": {
-    "en": ["Transparency", "Easy debugging", "Improved trust"],
-    "ko": ["투명성", "쉬운 디버깅", "향상된 신뢰"]
+    "en": [
+      "Enables debugging of unexpected agent behavior",
+      "Supports prompt engineering",
+      "Builds trust through explainability"
+    ],
+    "ko": [
+      "예상치 못한 에이전트 동작 디버깅 가능",
+      "프롬프트 엔지니어링 지원",
+      "설명 가능성을 통한 신뢰 구축"
+    ]
   },
   "cons": {
-    "en": ["Increased output volume", "Higher token costs"],
-    "ko": ["출력량 증가", "토큰 비용 증가"]
+    "en": [
+      "Adds modest performance overhead (+10-30% tokens)",
+      "Requires careful handling of sensitive information (system prompts, credentials)"
+    ],
+    "ko": [
+      "적당한 성능 오버헤드 추가 (+10-30% 토큰)",
+      "민감한 정보(시스템 프롬프트, 자격 증명) 처리에 주의 필요"
+    ]
   },
-  "tags": ["explainability", "debugging", "transparency", "verbose-mode"]
+  "tags": ["explainability", "debugging", "transparency", "agent reasoning", "verbose mode", "introspection"]
 }


### PR DESCRIPTION
## Summary
이슈 #49의 Batch 9 - 변경 규모 81-90위 10개 패턴 업데이트.

## 주요 변경
- `subagent-compilation-checker` 카테고리 변경: Tool Use & Environment → Reliability & Eval
- README/README_KR 카테고리별 수 업데이트

## 업데이트된 패턴
- tool-use-incentivization-via-reward-shaping
- multi-model-orchestration-for-complex-edits
- iterative-multi-agent-brainstorming
- episodic-memory-retrieval-injection
- patch-steering-via-prompted-tool-selection
- graph-of-thoughts
- democratization-of-tooling-via-agents
- verbose-reasoning-transparency
- subagent-compilation-checker
- rlaif-reinforcement-learning-from-ai-feedback

## Test plan
- [x] `npm test` 로컬 통과
- [x] JSON 유효성 검증

Part of #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)