### PR TITLE
feat: Update 10 patterns from upstream (batch 11)

### DIFF
--- a/src/data/patterns/adaptive-sandbox-fanout-controller.json
+++ b/src/data/patterns/adaptive-sandbox-fanout-controller.json
@@ -6,24 +6,50 @@
   "status": "emerging",
   "original_url": "https://github.com/nibzard/labruno-agent",
   "problem": {
-    "en": "Parallel sandboxes can spawn many runs, but static fan-out policies don't adapt to task difficulty. After some N, you're paying for redundant failures. If prompts are underspecified, scaling N just scales errors. Unbounded fan-out can overwhelm budgets and rate limits.",
-    "ko": "병렬 샌드박스는 많은 실행을 생성할 수 있지만, 정적 팬아웃 정책은 작업 난이도에 적응하지 못합니다. 일정 N 이후에는 중복 실패에 비용을 지불합니다. 프롬프트가 불충분하면 N을 늘려도 오류만 확대됩니다. 무제한 팬아웃은 예산과 속도 제한을 초과할 수 있습니다."
+    "en": "Parallel sandboxes are intoxicating: you can spawn 10... 100... 1000 runs. But two things break quickly:\n\n1. **Diminishing returns:** After some N, you're mostly paying for redundant failures or near-duplicate solutions\n2. **Prompt fragility:** If the prompt is underspecified, scaling N just scales errors (lots of sandboxes fail fast)\n3. **Resource risk:** Unbounded fan-out can overwhelm budgets, rate limits, or queues\n4. **Oscillation risk:** Poorly tuned thresholds can cause scale-up/scale-down thrashing as the controller oscillates between decisions\n\nStatic \"N=10 always\" policies don't adapt to task difficulty, model variance, or observed failure rates. Most implementations use static caps rather than true signal-driven adaptation.",
+    "ko": "병렬 샌드박스는 매혹적입니다: 10개... 100개... 1000개 실행을 생성할 수 있습니다. 하지만 두 가지가 빠르게 문제가 됩니다:\n\n1. **수확 체감:** 일정 N 이후에는 대부분 중복 실패나 거의 동일한 솔루션에 비용을 지불합니다\n2. **프롬프트 취약성:** 프롬프트가 불충분하면 N을 늘려도 오류만 확대됩니다 (많은 샌드박스가 빠르게 실패)\n3. **리소스 위험:** 무제한 팬아웃은 예산, 속도 제한, 큐를 초과할 수 있습니다\n4. **진동 위험:** 튜닝이 부실한 임계값은 컨트롤러가 결정 사이에서 진동하면서 확장/축소 스래싱을 유발할 수 있습니다\n\n정적 \"N=10 항상\" 정책은 작업 난이도, 모델 분산, 관찰된 실패율에 적응하지 못합니다. 대부분의 구현은 진정한 신호 기반 적응이 아닌 정적 한도를 사용합니다."
   },
   "solution": {
-    "en": "Add a controller that adapts fan-out in real time based on observed signals. Start small (N=3-5), sample early signals (success rate, diversity, error clustering), then decide: scale up if variance is high, stop early if confident, refine prompt if errors cluster, or decompose if repeated failures occur.",
-    "ko": "관찰된 신호를 기반으로 실시간으로 팬아웃을 조정하는 컨트롤러를 추가합니다. 작게 시작(N=3-5)하고, 초기 신호(성공률, 다양성, 오류 클러스터링)를 샘플링한 후 결정합니다: 분산이 높으면 확장, 확신이 있으면 조기 중단, 오류가 클러스터링되면 프롬프트 개선, 반복 실패 시 분해합니다."
+    "en": "Add a controller that *adapts fan-out in real time* based on observed signals from early runs.\n\n**Core loop:**\n\n1. **Start small:** Launch a small batch (e.g., N=3-5) in parallel\n2. **Early signal sampling:** As soon as the first X runs finish (or after T seconds), compute:\n   - success rate (exit code / test pass)\n   - diversity score (are solutions meaningfully different?)\n   - judge confidence / winner margin\n   - error clustering (same error everywhere vs varied errors)\n\n3. **Decide next action:**\n   - **Scale up** if: success rate is good but quality variance is high (you want a better winner)\n   - **Stop early** if: judge is confident + tests pass + solutions converge\n   - **Refine prompt / spec** if: error clustering is high (everyone fails the same way)\n   - **Switch strategy** if: repeated failure suggests decomposition is needed (spawn investigative sub-agent)\n\n4. **Budget guardrails:** Enforce max sandboxes, max runtime, and \"no-progress\" stop conditions\n\n5. **Hysteresis for stability:** Use different thresholds for scale-up vs. stop (e.g., scale up if confidence < 0.65, stop only if > 0.75) to prevent oscillation",
+    "ko": "초기 실행에서 관찰된 신호를 기반으로 *실시간으로 팬아웃을 조정하는* 컨트롤러를 추가합니다.\n\n**핵심 루프:**\n\n1. **작게 시작:** 작은 배치(예: N=3-5)를 병렬로 시작합니다\n2. **초기 신호 샘플링:** 처음 X개 실행이 완료되면(또는 T초 후) 계산합니다:\n   - 성공률 (종료 코드 / 테스트 통과)\n   - 다양성 점수 (솔루션이 의미 있게 다른가?)\n   - 판정 신뢰도 / 승자 마진\n   - 오류 클러스터링 (모든 곳에서 같은 오류 vs 다양한 오류)\n\n3. **다음 행동 결정:**\n   - **확장**: 성공률은 좋지만 품질 분산이 높을 때 (더 나은 승자를 원함)\n   - **조기 중단**: 판정이 확실하고 + 테스트 통과 + 솔루션이 수렴할 때\n   - **프롬프트/사양 개선**: 오류 클러스터링이 높을 때 (모두 같은 방식으로 실패)\n   - **전략 전환**: 반복 실패가 분해가 필요함을 시사할 때 (조사 서브 에이전트 생성)\n\n4. **예산 가드레일:** 최대 샌드박스 수, 최대 실행 시간, \"진행 없음\" 중단 조건 적용\n\n5. **안정성을 위한 히스테리시스:** 확장과 중단에 다른 임계값 사용 (예: 신뢰도 < 0.65면 확장, > 0.75일 때만 중단)하여 진동 방지"
   },
   "when_to_use": {
-    "en": ["Best-of-N codegen with sandbox execution", "Tasks with cheap objective checks (unit tests, schema validation)", "When latency and cost matter - need minimum N for reliability"],
-    "ko": ["샌드박스 실행이 있는 Best-of-N 코드 생성", "저렴한 객관적 검사가 있는 작업(단위 테스트, 스키마 검증)", "지연과 비용이 중요할 때 - 신뢰성을 위한 최소 N 필요"]
+    "en": [
+      "Doing 'best-of-N codegen + execution' in sandboxes",
+      "Have cheap objective checks (unit tests, static analysis, schema validation)",
+      "Latency and cost matter: want the minimum N that achieves reliability"
+    ],
+    "ko": [
+      "샌드박스에서 'Best-of-N 코드 생성 + 실행' 수행",
+      "저렴한 객관적 검사 보유 (단위 테스트, 정적 분석, 스키마 검증)",
+      "지연과 비용이 중요: 신뢰성을 달성하는 최소 N 필요"
+    ]
   },
   "pros": {
-    "en": ["Prevents scaling errors when prompts are bad", "Lowers spend by stopping early when winner is clear", "Makes sandbox swarms production-safe via budgets"],
-    "ko": ["프롬프트가 나쁠 때 오류 확산 방지", "승자가 명확할 때 조기 중단으로 비용 절감", "예산을 통한 샌드박스 스웜 프로덕션 안전화"]
+    "en": [
+      "Prevents 'scale errors' when prompts are bad",
+      "Lowers spend by stopping early when a clear winner appears",
+      "Makes sandbox swarms production-safe via budgets and no-progress stopping"
+    ],
+    "ko": [
+      "프롬프트가 나쁠 때 '오류 확산' 방지",
+      "명확한 승자가 나타나면 조기 중단으로 비용 절감",
+      "예산과 진행 없음 중단을 통한 샌드박스 스웜 프로덕션 안전화"
+    ]
   },
   "cons": {
-    "en": ["Requires instrumentation for failure signatures and confidence", "Needs careful defaults to avoid oscillation", "Bad scoring functions can cause premature stopping"],
-    "ko": ["실패 서명과 신뢰도를 위한 계측 필요", "진동을 피하기 위한 신중한 기본값 필요", "나쁜 점수 함수는 조기 중단 유발 가능"]
+    "en": [
+      "Requires instrumentation (collecting failure signatures, confidence, diversity)",
+      "Needs careful defaults and hysteresis to avoid oscillation (scale up/down thrash)",
+      "Bad scoring functions can cause premature stopping",
+      "Few verified implementations; most systems use static caps instead of true signal-driven adaptation"
+    ],
+    "ko": [
+      "계측 필요 (실패 서명, 신뢰도, 다양성 수집)",
+      "진동(확장/축소 스래싱)을 피하기 위한 신중한 기본값과 히스테리시스 필요",
+      "나쁜 점수 함수가 조기 중단을 유발할 수 있음",
+      "검증된 구현이 적음; 대부분의 시스템이 진정한 신호 기반 적응 대신 정적 한도 사용"
+    ]
   },
   "mermaid_diagram": "flowchart TD\n    A[Task] --> B[Launch small batch N=3-5]\n    B --> C[Collect early results]\n    C --> D{Signals}\n    D -->|Good success + high variance| E[Increase N]\n    D -->|Good success + high confidence| F[Stop early + return winner]\n    D -->|Clustered failures| G[Prompt/spec refinement step]\n    D -->|Ambiguous / large task| H[Decompose + sub-agent investigation]\n    E --> C\n    G --> B\n    H --> B",
   "tags": ["fan-out", "adaptive", "parallel-sandboxes", "early-stopping", "controller", "variance", "prompt-refinement"]

--- a/src/data/patterns/agent-modes-by-model-personality.json
+++ b/src/data/patterns/agent-modes-by-model-personality.json
@@ -6,55 +6,61 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=4rx36wc9ugw",
   "problem": {
-    "en": "Different AI models have fundamentally different personalities and working styles. Treating all models the same leads to suboptimal outcomes. Some models are 'trigger happy' and want to run commands immediately, while others prefer thorough research before acting.",
-    "ko": "서로 다른 AI 모델은 근본적으로 다른 성격과 작업 스타일을 가지고 있습니다. 모든 모델을 동일하게 취급하면 최적이 아닌 결과가 발생합니다. 일부 모델은 즉시 명령을 실행하려 하고, 다른 모델은 행동 전 철저한 조사를 선호합니다."
+    "en": "Different AI models have fundamentally different personalities and working styles. Treating all models the same—expecting them to work identically—leads to suboptimal outcomes. Users expect a consistent interface, but models like Opus 4.5 are \"trigger happy\" and want to run commands immediately, while models like GPT-5.2 are \"lazy\" and prefer thorough research before acting.",
+    "ko": "서로 다른 AI 모델은 근본적으로 다른 성격과 작업 스타일을 가지고 있습니다. 모든 모델을 동일하게 취급하여 동일하게 작동하기를 기대하면 최적이 아닌 결과가 발생합니다. 사용자는 일관된 인터페이스를 기대하지만, Opus 4.5 같은 모델은 '트리거 해피'로 즉시 명령을 실행하려 하고, GPT-5.2 같은 모델은 '게으른' 성격으로 행동 전 철저한 조사를 선호합니다."
   },
   "solution": {
-    "en": "Design different agent modes optimized for each model's personality rather than forcing all models into a single interaction pattern. Each mode should have its own UI/UX patterns, tool configurations, expectation setting, and working style. Present these as different working modes (e.g., Smart Mode, Rush Mode, Deep Mode), not as a model selector dropdown.",
-    "ko": "모든 모델을 하나의 상호작용 패턴에 강제하는 대신, 각 모델의 성격에 최적화된 다른 에이전트 모드를 설계합니다. 각 모드는 고유한 UI/UX 패턴, 도구 구성, 기대치 설정, 작업 스타일을 가져야 합니다. 모델 선택 드롭다운이 아닌 다른 작업 모드(예: 스마트 모드, 러시 모드, 딥 모드)로 제시합니다."
+    "en": "Design **different agent modes** optimized for each model's personality rather than forcing all models into a single interaction pattern. Each mode should have its own UI/UX patterns (font, prompt length guidance), tool configurations, expectation setting, and working style.\n\n**Key insight:** It's not about model selection—it's about **different ways of working**.\n\n**Model personalities identified:**\n- **Claude Opus 4.5**: Trigger happy, interactive. Runs commands, asks questions, rapid feedback loops. Best for quick back-and-forth, interactive tasks.\n- **GPT-5.2**: Lazy, thorough, deep researcher. Goes off for 45+ minutes, researches extensively, comes back with comprehensive results. Best for well-scoped problems, big tasks, finding information.\n\n**Implementation mechanisms:**\n- System prompts: Define personality-specific instructions per mode\n- Temperature/sampling: Low (0.1-0.3) for consistent modes; medium (0.4-0.7) for balanced; high (0.7-1.0+) for creative modes\n- Tool configuration: Mode-specific permission sets and constraints\n\n**Mode differentiation strategies:**\n1. Visual/UI differentiation: Different fonts, prompt length guidance\n2. Tool configuration: Smart mode optimized for rapid execution; Deep mode optimized for thorough research\n3. Expectation setting: Smart mode \"Watch the agent work\"; Deep mode \"Send off and check in 60 minutes later\"",
+    "ko": "모든 모델을 하나의 상호작용 패턴에 강제하는 대신, 각 모델의 성격에 최적화된 **다른 에이전트 모드**를 설계합니다. 각 모드는 고유한 UI/UX 패턴(폰트, 프롬프트 길이 가이드), 도구 구성, 기대치 설정, 작업 스타일을 가져야 합니다.\n\n**핵심 통찰:** 모델 선택이 아닌 **다른 작업 방식**에 관한 것입니다.\n\n**식별된 모델 성격:**\n- **Claude Opus 4.5**: 트리거 해피, 대화형. 명령 실행, 질문, 빠른 피드백 루프. 빠른 상호작용 작업에 적합합니다.\n- **GPT-5.2**: 게으르지만 철저한 깊은 연구자. 45분 이상 연구하고 포괄적인 결과를 제공합니다. 범위가 명확한 문제, 큰 작업, 정보 수집에 적합합니다.\n\n**구현 메커니즘:**\n- 시스템 프롬프트: 모드별 성격 특화 지침 정의\n- 온도/샘플링: 일관된 모드는 낮게(0.1-0.3), 균형은 중간(0.4-0.7), 창의적 모드는 높게(0.7-1.0+)\n- 도구 구성: 모드별 권한 세트 및 제약 조건\n\n**모드 차별화 전략:**\n1. 시각적/UI 차별화: 다른 폰트, 프롬프트 길이 가이드\n2. 도구 구성: 스마트 모드는 빠른 실행에 최적화, 딥 모드는 철저한 조사에 최적화\n3. 기대치 설정: 스마트 모드 \"에이전트 작업 관찰\", 딥 모드 \"보내고 60분 후 확인\""
   },
   "when_to_use": {
     "en": [
-      "Multi-model agent systems with different model backends",
-      "Products supporting both interactive and autonomous workflows",
-      "When model personalities significantly differ in working style",
-      "User-facing AI tools requiring clear expectation setting"
+      "Identify model personalities in your stack through internal testing",
+      "Create mode names that describe the working style, not the model",
+      "Differentiate UX to make each mode feel distinct",
+      "Configure tools per mode optimized for the model's strength",
+      "Set user expectations explaining when to use each mode",
+      "Smart Mode (Opus-like): Quick configuration tasks, debugging with rapid iteration, tasks requiring frequent human feedback",
+      "Deep Mode (GPT-5.2-like): Well-scoped problems, big tasks with clear requirements, research and information gathering"
     ],
     "ko": [
-      "다양한 모델 백엔드를 가진 멀티 모델 에이전트 시스템",
-      "대화형과 자율 워크플로우를 모두 지원하는 제품",
-      "모델 성격이 작업 스타일에서 크게 다를 때",
-      "명확한 기대치 설정이 필요한 사용자 대면 AI 도구"
+      "내부 테스트를 통해 스택 내 모델 성격 파악",
+      "모델이 아닌 작업 스타일을 설명하는 모드 이름 생성",
+      "각 모드가 구별되도록 UX 차별화",
+      "모델의 강점에 최적화된 모드별 도구 구성",
+      "각 모드의 사용 시기를 설명하는 사용자 기대치 설정",
+      "스마트 모드(Opus 유형): 빠른 구성 작업, 빠른 반복 디버깅, 빈번한 인간 피드백이 필요한 작업",
+      "딥 모드(GPT-5.2 유형): 범위가 명확한 문제, 명확한 요구사항의 큰 작업, 연구 및 정보 수집"
     ]
   },
   "pros": {
     "en": [
-      "Optimized for each model's strengths",
-      "Clear user expectations per mode",
-      "Reduced user frustration",
-      "Better outcomes through model-appropriate workflows"
+      "Optimized for each model's strengths: Better outcomes than one-size-fits-all",
+      "Clear user expectations: Users know how to interact with each mode",
+      "Reduced frustration: Users don't fight against model's natural tendencies",
+      "Better outcomes: Different models get to equally good results via different paths"
     ],
     "ko": [
-      "각 모델의 강점에 최적화",
-      "모드별 명확한 사용자 기대치",
-      "사용자 불만 감소",
-      "모델에 적합한 워크플로우를 통한 향상된 결과"
+      "각 모델의 강점에 최적화: 획일적 접근보다 나은 결과",
+      "명확한 사용자 기대치: 사용자가 각 모드와 상호작용하는 방법을 인지",
+      "불만 감소: 사용자가 모델의 자연스러운 경향에 맞서 싸우지 않음",
+      "향상된 결과: 다른 모델이 다른 경로를 통해 동등하게 좋은 결과에 도달"
     ]
   },
   "cons": {
     "en": [
-      "Increased complexity with multiple modes to maintain",
-      "User confusion about which mode to choose",
-      "Model evolution risk as personalities change with new versions",
-      "Testing overhead for each mode independently"
+      "Increased complexity: Multiple modes to maintain and document",
+      "User confusion: Some users just want \"the best model\"",
+      "Model evolution risk: Personalities change with new versions",
+      "Testing overhead: Need to validate each mode independently"
     ],
     "ko": [
-      "유지해야 할 여러 모드로 인한 복잡성 증가",
-      "어떤 모드를 선택할지에 대한 사용자 혼란",
-      "새 버전에서 성격이 변하는 모델 진화 위험",
-      "각 모드의 독립적 테스트 오버헤드"
+      "복잡성 증가: 유지 및 문서화할 여러 모드",
+      "사용자 혼란: 일부 사용자는 단순히 '최고의 모델'을 원함",
+      "모델 진화 위험: 새 버전에서 성격이 변경됨",
+      "테스트 오버헤드: 각 모드를 독립적으로 검증 필요"
     ]
   },
   "mermaid_diagram": "graph LR\n    A[User Request] --> B{Select Mode}\n    B -->|Smart Mode| C[Opus 4.5]\n    B -->|Deep Mode| D[GPT-5.2]\n    C --> E[Interactive: Fast feedback, rapid iteration]\n    D --> F[Autonomous: Send off, check back later]\n    E --> G[Results in minutes]\n    F --> H[Results in 45-60 minutes]",
-  "tags": ["model-personality", "interaction-modes", "multi-model", "ux-design", "agent-behavior"]
+  "tags": ["model-personality", "interaction-modes", "multi-model", "ux-design", "agent-behavior", "opus", "gpt-52"]
 }

--- a/src/data/patterns/ai-assisted-code-review-verification.json
+++ b/src/data/patterns/ai-assisted-code-review-verification.json
@@ -6,27 +6,51 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=BGgsoIgbT_Y",
   "problem": {
-    "en": "As AI generates increasing amounts of code, the bottleneck shifts from generation to verification. Ensuring AI-generated code is semantically correct, aligns with intent (especially if underspecified), and meets quality standards becomes crucial and time-consuming.",
-    "ko": "AI가 점점 더 많은 코드를 생성함에 따라 병목 현상이 생성에서 검증으로 이동합니다. AI 생성 코드가 의미적으로 올바르고, 의도(특히 불충분하게 지정된 경우)에 부합하며, 품질 표준을 충족하는지 확인하는 것이 중요하고 시간이 많이 걸립니다."
+    "en": "As AI models generate increasing amounts of code, the bottleneck in software development shifts from code generation to code verification and review. Ensuring that AI-generated code is not only syntactically correct but also semantically correct, aligns with the intended functionality (especially if underspecified), and meets quality standards becomes crucial and time-consuming.",
+    "ko": "AI 모델이 점점 더 많은 코드를 생성함에 따라 소프트웨어 개발의 병목 현상이 코드 생성에서 코드 검증 및 리뷰로 이동합니다. AI 생성 코드가 구문적으로 올바를 뿐만 아니라 의미적으로도 올바르고, 의도된 기능(특히 불충분하게 지정된 경우)에 부합하며, 품질 표준을 충족하는지 확인하는 것이 중요하고 시간이 많이 걸립니다."
   },
   "solution": {
-    "en": "Employ AI-powered tools to assist code review: analyze changes and highlight potential issues, summarize intent/impact of changes, interactive systems for explaining code or justifying decisions, ensure alignment with user's 'mind's eye' intent.",
-    "ko": "AI 기반 도구를 사용하여 코드 리뷰 지원: 변경 사항 분석 및 잠재적 문제 강조, 변경의 의도/영향 요약, 코드 설명 또는 결정 정당화를 위한 대화형 시스템, 사용자의 '마음의 눈' 의도와의 일치 보장."
+    "en": "Develop and employ AI-powered tools and processes specifically designed to assist humans in reviewing and verifying code, whether it's AI-generated or human-written. This can involve:\n\n- AI agents that analyze code changes and highlight potential issues, bugs, or deviations from best practices.\n- Tools that help summarize the intent or impact of code changes, making it easier for human reviewers to understand.\n- Interactive systems where reviewers can ask the AI to explain parts of the code or justify certain decisions made during generation.\n- Mechanisms to ensure the AI's output aligns with the user's \"mind's eye\" or high-level intent, even if the initial specification was ambiguous.\n- Multi-agent approaches where one agent generates code while another critiques and verifies it, iterating until convergence.\n- Three-layer workflows stratifying tasks by complexity: AI-only for style/documentation, AI-human collaboration for logic/security, and human-only for architectural decisions.\n\nThe goal is to make the code review process more efficient and reliable, building confidence in the (AI-assisted) codebase.",
+    "ko": "AI 생성 코드든 인간이 작성한 코드든, 코드 리뷰 및 검증을 지원하기 위해 특별히 설계된 AI 기반 도구와 프로세스를 개발하고 활용합니다. 여기에는 다음이 포함됩니다:\n\n- 코드 변경 사항을 분석하고 잠재적 문제, 버그 또는 모범 사례 이탈을 강조하는 AI 에이전트\n- 코드 변경의 의도나 영향을 요약하여 인간 리뷰어의 이해를 돕는 도구\n- 리뷰어가 AI에게 코드의 일부를 설명하거나 생성 중 내린 결정을 정당화하도록 요청할 수 있는 대화형 시스템\n- 초기 명세가 모호하더라도 AI 출력이 사용자의 '마음의 눈' 또는 상위 의도에 부합하도록 보장하는 메커니즘\n- 하나의 에이전트가 코드를 생성하고 다른 에이전트가 비평 및 검증하여 수렴할 때까지 반복하는 멀티 에이전트 접근 방식\n- 복잡도별 작업 계층화: 스타일/문서화는 AI 전용, 로직/보안은 AI-인간 협업, 아키텍처 결정은 인간 전용의 3계층 워크플로우\n\n목표는 코드 리뷰 프로세스를 더 효율적이고 신뢰할 수 있게 만들어 (AI 지원) 코드베이스에 대한 신뢰를 구축하는 것입니다."
   },
   "ascii_diagram": "┌─────────────────────────────────┐\n│   AI-Generated Code Changes     │\n└───────────────┬─────────────────┘\n                │\n┌───────────────▼─────────────────┐\n│    AI Review Assistant          │\n├─────────────────────────────────┤\n│ • Analyze changes               │\n│ • Highlight potential issues    │\n│ • Summarize intent/impact       │\n│ • Explain code decisions        │\n└───────────────┬─────────────────┘\n                │\n┌───────────────▼─────────────────┐\n│      Human Reviewer             │\n│  Focus on high-level intent     │\n│  and business logic             │\n└───────────────┬─────────────────┘\n                │\n┌───────────────▼─────────────────┐\n│   Confident Codebase            │\n└─────────────────────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[AI-Generated Code] --> B[AI Review Assistant]\n    B --> C[Analyze Changes]\n    B --> D[Highlight Issues]\n    B --> E[Summarize Intent]\n    C --> F[Human Reviewer]\n    D --> F\n    E --> F\n    F --> G{Aligns with Intent?}\n    G -->|Yes| H[Approve]\n    G -->|No| I[Request Changes]",
   "code_example": "# AI-Assisted Code Review Integration\n\nclass AICodeReviewAssistant:\n    def review_changes(self, diff):\n        analysis = {\n            'issues': self.detect_potential_issues(diff),\n            'intent_summary': self.summarize_intent(diff),\n            'impact_analysis': self.analyze_impact(diff),\n            'questions': self.generate_review_questions(diff)\n        }\n        return analysis\n    \n    def explain_decision(self, code_section, question):\n        # Interactive Q&A about code decisions\n        return self.explain(code_section, question)\n\n# Integration into PR review process\ndef review_pr(pr):\n    ai_review = assistant.review_changes(pr.diff)\n    \n    # Human focuses on alignment with intent\n    print(f\"Intent Summary: {ai_review['intent_summary']}\")\n    print(f\"Potential Issues: {ai_review['issues']}\")\n    \n    # Human can ask clarifying questions\n    explanation = assistant.explain_decision(\n        pr.diff, \"Why was this approach chosen?\"\n    )",
   "when_to_use": {
-    "en": ["Reviewing large AI-generated changes", "Verifying alignment with underspecified intent", "PR review process integration", "Building confidence in AI-assisted codebases"],
-    "ko": ["대규모 AI 생성 변경 검토", "불충분하게 지정된 의도와의 일치 검증", "PR 리뷰 프로세스 통합", "AI 지원 코드베이스에 대한 신뢰 구축"]
+    "en": [
+      "Integrate AI verification tools into the PR review process",
+      "Prompt agents to explain their generated code or provide rationales for changes",
+      "Focus human review on verifying alignment with high-level intent and business logic"
+    ],
+    "ko": [
+      "PR 리뷰 프로세스에 AI 검증 도구 통합",
+      "에이전트에게 생성된 코드 설명 또는 변경 근거 제공 요청",
+      "상위 의도 및 비즈니스 로직과의 일치 검증에 인간 리뷰 집중"
+    ]
   },
   "pros": {
-    "en": ["Makes review more efficient", "Highlights issues humans might miss", "Summarizes complex changes", "Interactive explanation capability"],
-    "ko": ["리뷰를 더 효율적으로", "인간이 놓칠 수 있는 문제 강조", "복잡한 변경 요약", "대화형 설명 기능"]
+    "en": [
+      "Reduces time spent on routine review tasks",
+      "Enables consistent enforcement of coding standards",
+      "Can identify issues humans miss through multi-agent debate and self-critique loops"
+    ],
+    "ko": [
+      "일상적인 리뷰 작업 시간 단축",
+      "코딩 표준의 일관된 시행 가능",
+      "멀티 에이전트 토론과 자기 비평 루프를 통해 인간이 놓치는 문제 식별 가능"
+    ]
   },
   "cons": {
-    "en": ["AI may miss subtle bugs", "Over-reliance risk", "Explanation quality varies", "Adds tooling complexity"],
-    "ko": ["AI가 미묘한 버그를 놓칠 수 있음", "과도한 의존 위험", "설명 품질 차이", "도구 복잡성 추가"]
+    "en": [
+      "Risk of hallucination (reviewing non-existent code or making uncited claims)",
+      "High false positive rates can lead to alert fatigue",
+      "Teams heavily adopting AI assistants have seen significant increases in PR review time due to the volume of AI-generated changes requiring verification"
+    ],
+    "ko": [
+      "환각 위험 (존재하지 않는 코드 리뷰 또는 출처 없는 주장)",
+      "높은 오탐률로 인한 경고 피로 발생 가능",
+      "AI 어시스턴트를 적극 도입한 팀에서 검증이 필요한 AI 생성 변경량으로 인해 PR 리뷰 시간이 크게 증가"
+    ]
   },
-  "tags": ["code-review", "verification", "quality-assurance", "human-ai-collaboration", "trust", "explainability"]
+  "tags": ["code-review", "verification", "quality-assurance", "human-ai-collaboration", "trust", "explainability", "software-quality"]
 }

--- a/src/data/patterns/context-window-auto-compaction.json
+++ b/src/data/patterns/context-window-auto-compaction.json
@@ -6,24 +6,56 @@
   "status": "validated-in-production",
   "original_url": "https://github.com/clawdbot/clawdbot/blob/main/src/agents/pi-embedded-runner/compact.ts",
   "problem": {
-    "en": "Context overflow is a silent killer of agent reliability. When accumulated conversation history exceeds the model's context window, API errors occur, requiring manual intervention and complex retry logic.",
-    "ko": "컨텍스트 오버플로우는 에이전트 신뢰성의 조용한 킬러입니다. 누적된 대화 기록이 모델의 컨텍스트 윈도우를 초과하면 API 오류가 발생하여 수동 개입과 복잡한 재시도 로직이 필요합니다."
+    "en": "Context overflow is a silent killer of agent reliability. When accumulated conversation history exceeds the model's context window:\n\n- **API errors**: Requests fail with `context_length_exceeded` or similar errors\n- **Manual intervention**: Operators must truncate transcripts, losing valuable context\n- **Retry complexity**: Detecting overflow and retrying with compaction is error-prone\n\nAgents need automatic compaction that preserves essential information while staying within token limits, with model-specific validation and reserve token floors to prevent immediate re-overflow.",
+    "ko": "컨텍스트 오버플로우는 에이전트 신뢰성의 조용한 킬러입니다. 누적된 대화 기록이 모델의 컨텍스트 윈도우를 초과하면:\n\n- **API 오류**: `context_length_exceeded` 또는 유사한 오류로 요청 실패\n- **수동 개입**: 운영자가 트랜스크립트를 잘라야 하며, 귀중한 컨텍스트 손실\n- **재시도 복잡성**: 오버플로우를 감지하고 압축하여 재시도하는 것이 오류에 취약\n\n에이전트는 토큰 제한 내에서 필수 정보를 보존하면서 즉각적 재오버플로우를 방지하기 위한 모델별 검증과 예비 토큰 하한을 갖춘 자동 압축이 필요합니다."
   },
   "solution": {
-    "en": "Automatic session compaction triggered by context overflow errors, with smart reserve tokens and lane-aware retry. Two approaches: (1) Client-side summarization that compacts transcripts locally, (2) API-based compaction (e.g., OpenAI's /responses/compact endpoint) that preserves latent understanding via encrypted_content. The system detects overflow, compacts the session, validates the result, and retries transparently.",
-    "ko": "컨텍스트 오버플로우 오류 시 자동 세션 압축을 트리거하고, 스마트 예비 토큰과 레인 인식 재시도를 수행합니다. 두 가지 접근법: (1) 로컬에서 트랜스크립트를 압축하는 클라이언트 측 요약, (2) encrypted_content를 통해 잠재적 이해를 보존하는 API 기반 압축(예: OpenAI의 /responses/compact 엔드포인트). 시스템이 오버플로우를 감지하고, 세션을 압축하고, 결과를 검증한 후 투명하게 재시도합니다."
+    "en": "Automatic session compaction triggered by context overflow errors, with smart reserve tokens and lane-aware retry. The system detects overflow, compacts the session transcript, validates the result, and retries the request—all transparently to the user.\n\n**Core concepts:**\n\n- **Overflow detection**: Catches API errors indicating context length exceeded (`context_length_exceeded`, `prompt is too long`, etc.).\n- **Auto-retry with compaction**: On overflow, the session is compacted and the request is retried automatically.\n- **Reserve token floor**: Post-compaction, ensures a minimum number of tokens (default 20k) remain available to prevent immediate re-overflow.\n- **Lane-aware compaction**: Uses hierarchical lane queuing (session → global) to prevent deadlocks during compaction.\n- **Post-compaction verification**: Estimates token count after compaction and verifies it's less than the pre-compaction count.\n- **Model-specific validation**: Anthropic models require strict turn ordering; Gemini models have different transcript requirements.\n\n**Two complementary approaches:**\n\nThis pattern describes **reactive compaction** (detect overflow, compact, retry). An alternative approach is **preventive filtering** (reduce context at ingestion), used by systems like HyperAgent for browser accessibility tree extraction. Preventive filtering can delay or eliminate the need for reactive compaction by keeping context leaner from the start.\n\n**API-based compaction (OpenAI Responses API):**\n\nSome providers offer dedicated compaction endpoints that are more efficient than manual summarization:\n- **Preserves latent understanding**: The `encrypted_content` maintains the model's compressed representation of the original conversation\n- **More efficient**: Server-side compaction is faster than client-side summarization\n- **Auto-compaction**: Can trigger automatically when `auto_compact_limit` is exceeded",
+    "ko": "컨텍스트 오버플로우 오류 시 자동 세션 압축을 트리거하고, 스마트 예비 토큰과 레인 인식 재시도를 수행합니다. 시스템이 오버플로우를 감지하고, 세션 트랜스크립트를 압축하고, 결과를 검증한 후 요청을 재시도합니다—모두 사용자에게 투명하게 진행됩니다.\n\n**핵심 개념:**\n\n- **오버플로우 감지**: 컨텍스트 길이 초과를 나타내는 API 오류를 포착합니다 (`context_length_exceeded`, `prompt is too long` 등).\n- **압축 후 자동 재시도**: 오버플로우 시 세션이 압축되고 요청이 자동으로 재시도됩니다.\n- **예비 토큰 하한**: 압축 후 최소 토큰 수(기본 20k)가 사용 가능하도록 하여 즉각적 재오버플로우를 방지합니다.\n- **레인 인식 압축**: 계층적 레인 큐잉(세션 → 글로벌)을 사용하여 압축 중 교착 상태를 방지합니다.\n- **압축 후 검증**: 압축 후 토큰 수를 추정하고 압축 전보다 적은지 확인합니다.\n- **모델별 검증**: Anthropic 모델은 엄격한 턴 순서가 필요하고, Gemini 모델은 다른 트랜스크립트 요구사항을 가집니다.\n\n**두 가지 보완적 접근법:**\n\n이 패턴은 **반응적 압축**(오버플로우 감지, 압축, 재시도)을 설명합니다. 대안적 접근법은 **예방적 필터링**(수집 시 컨텍스트 축소)으로, HyperAgent가 브라우저 접근성 트리 추출에 사용합니다. 예방적 필터링은 처음부터 컨텍스트를 간결하게 유지하여 반응적 압축의 필요성을 지연시키거나 제거할 수 있습니다.\n\n**API 기반 압축 (OpenAI Responses API):**\n\n일부 제공자는 수동 요약보다 효율적인 전용 압축 엔드포인트를 제공합니다:\n- **잠재적 이해 보존**: `encrypted_content`가 원래 대화의 압축된 표현을 유지\n- **더 효율적**: 서버 측 압축이 클라이언트 측 요약보다 빠름\n- **자동 압축**: `auto_compact_limit` 초과 시 자동으로 트리거 가능"
   },
   "when_to_use": {
-    "en": ["Long-running agent sessions", "Multi-turn conversations", "Tool-heavy workflows with large outputs"],
-    "ko": ["장시간 실행 에이전트 세션", "다중 턴 대화", "대용량 출력이 있는 도구 집약적 워크플로우"]
+    "en": [
+      "Configure reserve floor: set compaction.reserveTokensFloor to ensure headroom after compaction (default 20k)",
+      "Handle overflow errors: catch API errors, detect overflow via error message matching, then trigger compaction",
+      "Validate transcripts: apply model-specific validation (Anthropic turns, Gemini ordering) before retry",
+      "Estimate post-compaction tokens: verify that compaction actually reduced token count before retrying",
+      "Use lane queuing: run compaction through hierarchical lanes to avoid deadlocks with concurrent operations"
+    ],
+    "ko": [
+      "예비 하한 설정: 압축 후 여유 공간 확보를 위해 compaction.reserveTokensFloor 설정 (기본 20k)",
+      "오버플로우 오류 처리: API 오류를 포착하고 오류 메시지 매칭으로 오버플로우 감지 후 압축 트리거",
+      "트랜스크립트 검증: 재시도 전 모델별 검증(Anthropic 턴, Gemini 순서) 적용",
+      "압축 후 토큰 추정: 재시도 전 압축이 실제로 토큰 수를 줄였는지 확인",
+      "레인 큐잉 사용: 동시 작업과의 교착 상태를 피하기 위해 계층적 레인을 통해 압축 실행"
+    ]
   },
   "pros": {
-    "en": ["Transparent recovery from overflow", "Preserves essential context via summaries", "Prevents immediate re-overflow with reserve tokens", "Model-aware validation"],
-    "ko": ["오버플로우에서 투명한 복구", "요약을 통한 필수 컨텍스트 보존", "예비 토큰으로 즉각적 재오버플로우 방지", "모델 인식 검증"]
+    "en": [
+      "Transparent recovery: overflow errors are handled automatically without user intervention",
+      "Preserve essential context: compaction generates summaries rather than arbitrary truncation",
+      "Prevents re-overflow: reserve token floor ensures immediate re-overflow is unlikely",
+      "Model-aware: different validation rules per provider ensure API compatibility"
+    ],
+    "ko": [
+      "투명한 복구: 오버플로우 오류가 사용자 개입 없이 자동으로 처리",
+      "필수 컨텍스트 보존: 압축이 임의 잘라내기가 아닌 요약을 생성",
+      "재오버플로우 방지: 예비 토큰 하한으로 즉각적 재오버플로우 방지",
+      "모델 인식: 제공자별 다른 검증 규칙으로 API 호환성 보장"
+    ]
   },
   "cons": {
-    "en": ["Summary quality may lose nuanced details", "Latency penalty during compaction", "Token estimation errors possible", "Implementation complexity"],
-    "ko": ["요약 품질이 세부 뉘앙스를 잃을 수 있음", "압축 중 지연 발생", "토큰 추정 오류 가능", "구현 복잡성"]
+    "en": [
+      "Summary quality: auto-generated summaries may lose nuanced details that manual curation would preserve",
+      "Latency penalty: compaction and retry adds overhead (seconds to minutes depending on context size)",
+      "Token estimation errors: heuristics may misestimate actual token counts, leading to failed retries",
+      "Complexity: lane-aware queuing and model-specific validation increase implementation complexity"
+    ],
+    "ko": [
+      "요약 품질: 자동 생성된 요약이 수동 큐레이션이 보존할 세부 뉘앙스를 잃을 수 있음",
+      "지연 패널티: 압축과 재시도가 오버헤드 추가 (컨텍스트 크기에 따라 초~분 단위)",
+      "토큰 추정 오류: 휴리스틱이 실제 토큰 수를 잘못 추정하여 재시도 실패 가능",
+      "복잡성: 레인 인식 큐잉과 모델별 검증이 구현 복잡성 증가"
+    ]
   },
-  "tags": ["context-management", "compaction", "overflow-recovery", "token-estimation", "api-compaction"]
+  "tags": ["context-management", "compaction", "overflow-recovery", "token-estimation", "transcript-validation", "api-compaction"]
 }

--- a/src/data/patterns/criticgpt-style-evaluation.json
+++ b/src/data/patterns/criticgpt-style-evaluation.json
@@ -6,27 +6,67 @@
   "status": "validated-in-production",
   "original_url": "https://openai.com/research/criticgpt",
   "problem": {
-    "en": "Human reviewers may miss subtle bugs in AI-generated code, especially as models become more sophisticated.",
-    "ko": "인간 리뷰어가 AI 생성 코드의 미묘한 버그를 놓칠 수 있습니다, 특히 모델이 더 정교해짐에 따라."
+    "en": "As AI-generated code becomes more sophisticated, it becomes increasingly difficult for human reviewers to catch subtle bugs, security issues, or quality problems. Traditional code review processes may miss issues in AI-generated code because the volume of generated code can overwhelm human reviewers, subtle bugs may appear correct at first glance, security vulnerabilities may be non-obvious, and style and best practice violations may be inconsistent.",
+    "ko": "AI 생성 코드가 더욱 정교해짐에 따라 인간 리뷰어가 미묘한 버그, 보안 문제 또는 품질 문제를 포착하기가 점점 더 어려워집니다. 기존 코드 리뷰 프로세스는 AI 생성 코드의 문제를 놓칠 수 있습니다. 생성된 코드의 양이 인간 리뷰어를 압도할 수 있고, 미묘한 버그가 언뜻 올바르게 보일 수 있으며, 보안 취약점이 명확하지 않을 수 있고, 스타일 및 모범 사례 위반이 일관되지 않을 수 있기 때문입니다."
   },
   "solution": {
-    "en": "Deploy specialized AI models trained specifically for code critique and bug detection to assist human reviewers.",
-    "ko": "코드 비판과 버그 감지를 위해 특별히 훈련된 전문 AI 모델을 배포하여 인간 리뷰어를 지원합니다."
+    "en": "Deploy specialized AI models trained specifically for code critique and evaluation. This approach builds on RLAIF (Reinforcement Learning from AI Feedback), which achieves ~100x cost reduction compared to human-only annotation. These models act as automated code reviewers that can:\n\n1. **Identify bugs** that human reviewers might miss\n2. **Detect security vulnerabilities** in generated code\n3. **Suggest improvements** for code quality and efficiency\n4. **Verify correctness** of implemented solutions\n5. **Check adherence** to coding standards and best practices\n\nThe critic model works alongside code generation models, providing an additional layer of quality assurance before code reaches human review or production.",
+    "ko": "코드 비평과 평가를 위해 특별히 훈련된 전문 AI 모델을 배포합니다. 이 접근 방식은 RLAIF(AI 피드백 기반 강화 학습)를 기반으로 하며, 인간 전용 어노테이션 대비 약 100배의 비용 절감을 달성합니다. 이 모델들은 자동화된 코드 리뷰어로서 다음을 수행합니다:\n\n1. 인간 리뷰어가 놓칠 수 있는 **버그 식별**\n2. 생성된 코드의 **보안 취약점 탐지**\n3. 코드 품질과 효율성을 위한 **개선 제안**\n4. 구현된 솔루션의 **정확성 검증**\n5. 코딩 표준 및 모범 사례 **준수 확인**\n\n비평 모델은 코드 생성 모델과 함께 작동하며, 코드가 인간 리뷰 또는 프로덕션에 도달하기 전에 추가적인 품질 보증 계층을 제공합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│ AI Code     │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│ CriticGPT   │\n├─────────────┤\n│✓ Bugs       │\n│✓ Security   │\n│✓ Quality    │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│Human Review │\n│ (Focused)   │\n└─────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Generated Code] --> B[CriticGPT]\n    B --> C[Bug Analysis]\n    B --> D[Security Audit]\n    B --> E[Quality Check]\n    C & D & E --> F[Report]\n    F --> G[Human Review - Focused]",
   "code_example": "class CriticGPT:\n    def review(self, code: str) -> Report:\n        bugs = self.detect_bugs(code)\n        security = self.security_audit(code)\n        quality = self.quality_check(code)\n        \n        return Report(\n            issues=bugs + security,\n            quality_score=quality,\n            recommendations=self.suggest_fixes(bugs)\n        )\n\n# Assist human reviewers\nreport = critic.review(generated_code)\nhuman_review.focus_on(report.high_priority_issues)",
   "when_to_use": {
-    "en": ["AI code review pipelines", "Security audits", "Quality gates"],
-    "ko": ["AI 코드 리뷰 파이프라인", "보안 감사", "품질 게이트"]
+    "en": [
+      "Automated code review workflows with high commit volumes",
+      "CI/CD pipelines for pre-commit quality checks",
+      "Security-sensitive code requiring vulnerability detection",
+      "Git webhook integration for event-driven review",
+      "3-4 iterations of critique-refinement loops for complex changes",
+      "Mitigating collapse risks by decoupling evaluation/generation prompts and benchmarking against human-labeled anchor sets"
+    ],
+    "ko": [
+      "높은 커밋 볼륨의 자동화된 코드 리뷰 워크플로우",
+      "사전 커밋 품질 검사를 위한 CI/CD 파이프라인",
+      "취약점 탐지가 필요한 보안 민감 코드",
+      "이벤트 기반 리뷰를 위한 Git 웹훅 통합",
+      "복잡한 변경에 대한 3-4회 비평-개선 루프",
+      "평가/생성 프롬프트 분리 및 인간 라벨 앵커 세트 벤치마킹을 통한 붕괴 위험 완화"
+    ]
   },
   "pros": {
-    "en": ["Consistent inspection", "24/7 availability", "Catches subtle bugs"],
-    "ko": ["일관된 검사", "24/7 가용성", "미묘한 버그 포착"]
+    "en": [
+      "Scalable code review process",
+      "Consistent quality standards",
+      "Catches issues early in development",
+      "Can review code 24/7 without breaks",
+      "Improves over time with more training"
+    ],
+    "ko": [
+      "확장 가능한 코드 리뷰 프로세스",
+      "일관된 품질 표준",
+      "개발 초기에 문제 포착",
+      "24/7 중단 없이 코드 리뷰 가능",
+      "더 많은 훈련으로 시간이 지남에 따라 개선"
+    ]
   },
   "cons": {
-    "en": ["False positives possible", "Training costs", "Context limitations"],
-    "ko": ["오탐 가능", "훈련 비용", "맥락 한계"]
+    "en": [
+      "May have false positives requiring human verification",
+      "Training specialized critic models is resource-intensive",
+      "Cannot understand full business context like humans",
+      "May miss novel vulnerability types",
+      "Requires integration into existing workflows",
+      "Risk of evaluator-model collusion in self-critique loops (mitigate with anchor sets and adversarial examples)"
+    ],
+    "ko": [
+      "인간 검증이 필요한 오탐이 발생할 수 있음",
+      "전문 비평 모델 훈련에 많은 리소스 필요",
+      "인간처럼 전체 비즈니스 컨텍스트를 이해할 수 없음",
+      "새로운 취약점 유형을 놓칠 수 있음",
+      "기존 워크플로우에 통합 필요",
+      "자기 비평 루프에서 평가자-모델 공모 위험 (앵커 세트와 적대적 예제로 완화)"
+    ]
   },
-  "tags": ["evaluation", "code-review", "critique", "bug-detection"]
+  "tags": ["evaluation", "code-review", "critique", "quality-assurance", "bug-detection", "gpt-4"]
 }

--- a/src/data/patterns/custom-sandboxed-background-agent.json
+++ b/src/data/patterns/custom-sandboxed-background-agent.json
@@ -6,25 +6,27 @@
   "status": "emerging",
   "original_url": "https://engineering.ramp.com/post/why-we-built-our-background-agent",
   "problem": {
-    "en": "Off-the-shelf coding agents are either too generic (not integrated with company-specific environments), vendor-locked (tied to one model provider), or have limited context (can't access internal infrastructure). Companies need coding agents that work within their specific development environment, iterate with closed feedback loops, provide real-time visibility, and are model-agnostic.",
-    "ko": "기성 코딩 에이전트는 너무 일반적이거나(회사별 환경과 통합되지 않음), 특정 벤더에 종속되어 있거나(하나의 모델 제공자에 묶임), 제한된 컨텍스트를 가지고 있습니다(내부 인프라에 접근 불가). 기업은 특정 개발 환경에서 작동하고, 폐쇄 피드백 루프로 반복하고, 실시간 가시성을 제공하며, 모델에 구애받지 않는 코딩 에이전트가 필요합니다."
+    "en": "Off-the-shelf coding agents (e.g., Devin, Claude Code, Cursor) are either:\n\n- **Too generic** - Not deeply integrated with company-specific dev environments, tools, and workflows\n- **Vendor-locked** - Tightly coupled to one model provider, limiting flexibility and creating dependency\n- **Limited context** - Cannot access internal infrastructure, private repos, or company-specific tooling\n\nCompanies need coding agents that:\n\n- Work within their specific development environment\n- Can iterate with closed feedback loops (compiler, linter, tests)\n- Provide real-time visibility into agent progress\n- Are model-agnostic to switch providers as needed",
+    "ko": "기성 코딩 에이전트(예: Devin, Claude Code, Cursor)는 다음 중 하나에 해당합니다:\n\n- **너무 일반적** - 회사별 개발 환경, 도구, 워크플로우와 깊이 통합되지 않음\n- **벤더 종속** - 하나의 모델 제공자에 강하게 결합되어 유연성이 제한되고 종속성 생성\n- **제한된 컨텍스트** - 내부 인프라, 프라이빗 저장소, 회사별 도구에 접근 불가\n\n기업은 다음과 같은 코딩 에이전트가 필요합니다:\n\n- 특정 개발 환경 내에서 작동\n- 폐쇄 피드백 루프(컴파일러, 린터, 테스트)로 반복 가능\n- 에이전트 진행 상황에 대한 실시간 가시성 제공\n- 필요에 따라 제공자를 전환할 수 있는 모델 중립성"
   },
   "solution": {
-    "en": "Build a custom background agent that runs in a sandboxed environment identical to developers. Key components include: (1) Sandboxed execution environment using Modal or similar for ephemeral dev environments, (2) Real-time communication layer via WebSockets for streaming stdout/stderr, (3) Closed feedback loop with compiler errors, linter warnings, and test failures guiding iterations, (4) Model-agnostic architecture supporting multiple frontier models, (5) Company-specific integration with internal tooling and workflows.",
-    "ko": "개발자와 동일한 샌드박스 환경에서 실행되는 커스텀 백그라운드 에이전트를 구축합니다. 주요 구성 요소: (1) Modal 또는 유사 도구를 사용한 임시 개발 환경의 샌드박스 실행 환경, (2) stdout/stderr 스트리밍을 위한 WebSocket 기반 실시간 통신 레이어, (3) 컴파일러 에러, 린터 경고, 테스트 실패가 반복을 안내하는 폐쇄 피드백 루프, (4) 여러 프론티어 모델을 지원하는 모델 중립적 아키텍처, (5) 내부 도구 및 워크플로우와의 회사별 통합."
+    "en": "Build a **custom background agent** that runs in a sandboxed environment identical to developers, with:\n\n**1. Sandboxed Execution Environment**\n- Use infrastructure like Modal for ephemeral, sandboxed dev environments\n- Agent runs with same context: codebase, dependencies, dev tools\n- Isolated from production but mirroring development setup\n\n**2. Real-Time Communication Layer**\n- WebSocket connection streams stdout/stderr to client\n- User sees agent progress in real-time (not polling)\n- Two-way communication for prompts and status updates\n\n**3. Closed Feedback Loop**\n- Agent iterates autonomously with machine-readable feedback\n- Compiler errors, linter warnings, test failures guide iterations\n- Not 1-shot implementation - but iterative refinement\n\n**4. Model-Agnostic Architecture**\n- Support multiple frontier models via pluggable interface\n- Switch between providers without rewriting infrastructure\n- Leverage best model for specific task type\n\n**5. Company-Specific Integration**\n- Deep integration with internal tooling, scripts, and workflows\n- Access to private repos, internal APIs, documentation\n- Customized to team's specific development practices\n\n**6. Security Best Practices**\n- Network isolation with egress lockdown (default-deny outbound rules)\n- Tool authorization with pattern-based allow/deny lists\n- Execution limits: timeouts, resource caps, privilege restrictions\n- Comprehensive audit logging for all agent actions",
+    "ko": "개발자와 동일한 샌드박스 환경에서 실행되는 **커스텀 백그라운드 에이전트**를 구축합니다:\n\n**1. 샌드박스 실행 환경**\n- Modal과 같은 인프라를 사용한 임시 샌드박스 개발 환경\n- 에이전트가 동일한 컨텍스트에서 실행: 코드베이스, 의존성, 개발 도구\n- 프로덕션과 격리되지만 개발 환경을 미러링\n\n**2. 실시간 통신 레이어**\n- WebSocket 연결로 stdout/stderr를 클라이언트에 스트리밍\n- 사용자가 에이전트 진행 상황을 실시간으로 확인 (폴링 아님)\n- 프롬프트와 상태 업데이트를 위한 양방향 통신\n\n**3. 폐쇄 피드백 루프**\n- 에이전트가 기계 판독 가능한 피드백으로 자율적 반복\n- 컴파일러 에러, 린터 경고, 테스트 실패가 반복을 안내\n- 1회성 구현이 아닌 반복적 개선\n\n**4. 모델 중립적 아키텍처**\n- 플러그인 인터페이스를 통해 여러 프론티어 모델 지원\n- 인프라를 다시 작성하지 않고 제공자 간 전환\n- 특정 작업 유형에 최적 모델 활용\n\n**5. 회사별 통합**\n- 내부 도구, 스크립트, 워크플로우와 깊은 통합\n- 프라이빗 저장소, 내부 API, 문서에 접근\n- 팀의 특정 개발 관행에 맞춤화\n\n**6. 보안 모범 사례**\n- 이그레스 잠금을 통한 네트워크 격리 (기본 거부 아웃바운드 규칙)\n- 패턴 기반 허용/거부 목록을 통한 도구 인가\n- 실행 제한: 타임아웃, 리소스 한도, 권한 제한\n- 모든 에이전트 작업에 대한 포괄적 감사 로깅"
   },
   "when_to_use": {
     "en": [
       "Need deep integration with company-specific tools and workflows",
       "Want model flexibility without vendor lock-in",
       "Require real-time visibility into agent progress",
-      "Agent needs same development context as human developers"
+      "Agent needs same development context as human developers",
+      "Off-the-shelf agents (Devin, Cursor) work for generic tasks but can't deeply integrate with company infrastructure"
     ],
     "ko": [
       "회사별 도구 및 워크플로우와 깊은 통합 필요",
       "벤더 종속 없는 모델 유연성 필요",
       "에이전트 진행 상황 실시간 가시성 필요",
-      "에이전트가 개발자와 동일한 개발 컨텍스트 필요"
+      "에이전트가 개발자와 동일한 개발 컨텍스트 필요",
+      "기성 에이전트(Devin, Cursor)가 일반 작업에는 적합하지만 회사 인프라와 깊은 통합이 불가할 때"
     ]
   },
   "pros": {
@@ -46,9 +48,9 @@
   "cons": {
     "en": [
       "Engineering overhead - requires building and maintaining infrastructure",
-      "Security considerations - agent needs access to repos and credentials",
+      "Security considerations - agent needs access to repos, credentials",
       "Ongoing maintenance - unlike SaaS solutions, you own the ops burden",
-      "Requires DevOps expertise - sandbox management, WebSocket scaling"
+      "Requires devops expertise - sandbox management, websocket scaling"
     ],
     "ko": [
       "엔지니어링 오버헤드 - 인프라 구축 및 유지보수 필요",
@@ -57,6 +59,6 @@
       "DevOps 전문성 필요 - 샌드박스 관리, WebSocket 스케일링"
     ]
   },
-  "mermaid_diagram": "flowchart TD\n    subgraph Client[\"Developer's Machine\"]\n        UI[Web UI / CLI]\n    end\n\n    subgraph Infrastructure[\"Company Infrastructure\"]\n        Svc[Agent Service]\n        Sandbox[Sandboxed Dev Environment]\n        VCS[Git / Version Control]\n    end\n\n    UI -->|\"WebSocket: Send Prompt\"| Svc\n    UI <-->|\"WebSocket: Real-time Stream\"| Svc\n    Svc -->|\"Spin up sandbox\"| Sandbox\n    Sandbox <-->|\"Read/Write Files\"| VCS\n    Sandbox -->|\"Compiler/Linter/Test Feedback\"| Sandbox\n    Sandbox -->|\"Final PR/Result\"| Svc\n    Svc -->|\"Notification\"| UI",
+  "mermaid_diagram": "flowchart TD\n    subgraph Client[\"Developer's Machine\"]\n        UI[Web UI / CLI]\n    end\n\n    subgraph Infrastructure[\"Company Infrastructure\"]\n        Svc[Agent Service]\n        Sandbox[Sandboxed Dev Environment<br/>Modal / OpenCode]\n        VCS[Git / Version Control]\n    end\n\n    UI -->|\"WebSocket: Send Prompt\"| Svc\n    UI <-->|\"WebSocket: Real-time Stream<br/>stdout/stderr\"| Svc\n    Svc -->|\"Spin up sandbox\"| Sandbox\n    Sandbox <-->|\"Read/Write Files\"| VCS\n    Sandbox -->|\"Compiler/Linter/Test Feedback\"| Sandbox\n    Sandbox -->|\"Final PR/Result\"| Svc\n    Svc -->|\"Notification\"| UI",
   "tags": ["background-agent", "sandboxed", "model-agnostic", "real-time", "websocket", "custom-infra", "iterative"]
 }

--- a/src/data/patterns/dev-tooling-assumptions-reset.json
+++ b/src/data/patterns/dev-tooling-assumptions-reset.json
@@ -6,59 +6,61 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=2wjnV6F2arc",
   "problem": {
-    "en": "Traditional development tools are built on assumptions that no longer hold: that humans write code with effort and expertise, that changes are scarce and valuable, that linear workflows make sense. When agents write 90% of code, these tools create bottlenecks and friction.",
-    "ko": "전통적인 개발 도구는 더 이상 유효하지 않은 가정 위에 구축되어 있습니다: 인간이 노력과 전문성으로 코드를 작성하고, 변경 사항은 희소하고 가치 있으며, 선형 워크플로우가 합리적이라는 가정입니다. 에이전트가 코드의 90%를 작성할 때, 이러한 도구는 병목과 마찰을 만듭니다."
+    "en": "Traditional development tools are built on assumptions that no longer hold: that humans write code with effort and expertise, that changes are scarce and valuable, that linear workflows make sense. When agents write most code, these tools create bottlenecks and friction. Academic research confirms this is a paradigm shift requiring ecosystem-level rethinking, not incremental adjustments.",
+    "ko": "전통적인 개발 도구는 더 이상 유효하지 않은 가정 위에 구축되어 있습니다: 인간이 노력과 전문성으로 코드를 작성하고, 변경 사항은 희소하고 가치 있으며, 선형 워크플로우가 합리적이라는 가정입니다. 에이전트가 대부분의 코드를 작성하면 이러한 도구는 병목과 마찰을 만듭니다. 학술 연구에서도 이것이 점진적 조정이 아닌 생태계 수준의 재고가 필요한 패러다임 전환임을 확인합니다."
   },
   "solution": {
-    "en": "Re-examine dev tooling assumptions from first principles. When agents write most code, the perceived value of changes drops dramatically. Replace linear tickets with immediate agent dispatch, PR reviews with automated verification, sprint planning with continuous flow. Embrace the 'primordial soup' of continuous agent-generated code rather than discrete human changes.",
-    "ko": "개발 도구의 가정을 제1원칙에서 재검토합니다. 에이전트가 대부분의 코드를 작성하면 변경의 인식된 가치가 급격히 떨어집니다. 선형 티켓을 즉각적인 에이전트 디스패치로, PR 리뷰를 자동화된 검증으로, 스프린트 계획을 지속적 흐름으로 대체합니다. 이산적인 인간 변경 대신 에이전트가 지속적으로 생성하는 코드의 '원시 수프'를 수용합니다."
+    "en": "**Re-examine dev tooling assumptions** from first principles. When agents write most code, the perceived value of changes drops dramatically, and workflows optimized for human effort become inefficient.\n\n**The ticket example:**\n\n- **Old world**: Bug reported → Developer busy → Create ticket → Assign next week → Developer gets context → Fix\n- **New world**: Bug reported → Send agent immediately → Agent diagnoses and fixes in same time it takes to create a ticket\n\n**The code review example:**\n\nGitHub features assume changes are valuable (emoji reactions, assigning reviewers, careful consideration). But when agents write 90% of code, you can say: 'Generate 10 variations of this.'\n\n**New tooling principles:**\n\n1. **Immediate action**: Don't queue work, spawn agents instantly\n2. **Variation generation**: Generate 10 versions, pick best\n3. **Automated verification**: Tests > reviews\n4. **Direct integration**: Fewer handoffs, more automation\n5. **Observable execution**: See what agents are doing, not approve each step\n6. **Machine-readable output**: JSON/structured data > human-readable logs\n7. **Unified logging**: Single log stream for all system events (client, server, database)\n\n**The 'primordial soup' metaphor:**\n\nWhen agents generate code continuously, you don't have discrete changes—you have a bubbling, brewing ecosystem of code variants. This requires new mental models: not linear tickets but continuous streams, not PR reviews but automated quality gates, not sprint planning but real-time prioritization.\n\n**Industry examples:**\n- **Model Context Protocol (MCP)**: Universal 'USB-C for AI' standard replacing proprietary tool integrations\n- **Unified logging** (Sourcegraph): Single JSONL stream for all system events, optimized for agent consumption\n- **Code-first interfaces** (Cloudflare): LLMs write code to call tools, reducing tokens 10-100x\n- **CLI-first design**: Tools with `--json` flags for machine-readable output",
+    "ko": "**개발 도구의 가정을 제1원칙에서 재검토합니다.** 에이전트가 대부분의 코드를 작성하면 변경의 인식된 가치가 급격히 떨어지고, 인간 노력에 최적화된 워크플로우가 비효율적이 됩니다.\n\n**티켓 예시:**\n\n- **기존 방식**: 버그 보고 → 개발자 바쁨 → 티켓 생성 → 다음 주 배정 → 개발자 컨텍스트 파악 → 수정\n- **새로운 방식**: 버그 보고 → 에이전트 즉시 파견 → 에이전트가 티켓 생성에 걸리는 시간 안에 진단 및 수정\n\n**코드 리뷰 예시:**\n\nGitHub 기능은 변경이 가치 있다고 가정합니다(이모지 반응, 리뷰어 배정, 신중한 검토). 하지만 에이전트가 코드의 90%를 작성하면 '이것의 변형 10개를 생성해'라고 말할 수 있습니다.\n\n**새로운 도구 원칙:**\n\n1. **즉각적 행동**: 작업을 큐에 넣지 말고 에이전트를 즉시 생성\n2. **변형 생성**: 10개 버전을 생성하고 최선을 선택\n3. **자동화된 검증**: 리뷰보다 테스트\n4. **직접 통합**: 핸드오프를 줄이고 자동화를 늘림\n5. **관찰 가능한 실행**: 각 단계를 승인하지 말고 에이전트 활동을 관찰\n6. **기계 판독 가능 출력**: 사람이 읽는 로그보다 JSON/구조화된 데이터\n7. **통합 로깅**: 모든 시스템 이벤트를 위한 단일 로그 스트림\n\n**'원시 수프' 비유:**\n\n에이전트가 지속적으로 코드를 생성하면 이산적인 변경이 아닌 끓어오르는 코드 변형의 생태계가 됩니다. 새로운 멘탈 모델이 필요합니다: 선형 티켓이 아닌 지속적 스트림, PR 리뷰가 아닌 자동화된 품질 게이트, 스프린트 계획이 아닌 실시간 우선순위 지정.\n\n**업계 사례:**\n- **Model Context Protocol (MCP)**: 독점 도구 통합을 대체하는 범용 'AI용 USB-C' 표준\n- **통합 로깅** (Sourcegraph): 에이전트 소비에 최적화된 단일 JSONL 스트림\n- **코드 우선 인터페이스** (Cloudflare): LLM이 도구를 호출하는 코드를 작성하여 토큰 10~100배 절감\n- **CLI 우선 설계**: 기계 판독 가능한 출력을 위한 `--json` 플래그가 있는 도구"
   },
   "when_to_use": {
     "en": [
       "Agents writing majority of code (50%+)",
       "Team comfortable with autonomous agents",
       "Codebase has good automated testing",
+      "Can tolerate experimentation and failure",
       "Leadership committed to new ways of working"
     ],
     "ko": [
       "에이전트가 코드의 대부분(50% 이상)을 작성할 때",
       "팀이 자율 에이전트에 익숙할 때",
       "코드베이스에 좋은 자동화 테스트가 있을 때",
+      "실험과 실패를 허용할 수 있을 때",
       "리더십이 새로운 작업 방식에 전념할 때"
     ]
   },
   "pros": {
     "en": [
-      "Removes bottlenecks by eliminating waiting for human availability",
-      "Faster iteration with immediate agent investigation",
-      "Better exploration through parallel approach generation",
-      "Reduced ceremony around changes",
-      "Scalability as agent usage grows"
+      "Removes bottlenecks: no waiting for human availability",
+      "Faster iteration: agents investigate immediately",
+      "Better exploration: generate multiple approaches in parallel",
+      "Reduced ceremony: less overhead around changes",
+      "Scalability: works better as agent usage grows"
     ],
     "ko": [
-      "인간 가용성 대기를 제거하여 병목 해소",
-      "즉각적인 에이전트 조사로 빠른 반복",
-      "병렬 접근 방식 생성을 통한 탐색 향상",
-      "변경 주변 절차 감소",
-      "에이전트 사용 증가에 따른 확장성"
+      "병목 제거: 인간 가용성 대기 불필요",
+      "빠른 반복: 에이전트가 즉시 조사",
+      "탐색 향상: 여러 접근 방식을 병렬로 생성",
+      "절차 감소: 변경 관련 오버헤드 감소",
+      "확장성: 에이전트 사용 증가에 따라 더 효과적"
     ]
   },
   "cons": {
     "en": [
-      "Loss of visibility into what's happening",
-      "Integration challenges with existing tools",
-      "Team resistance to unfamiliar workflows",
-      "Increased blast radius with more automation",
-      "Transition pain with hybrid human/agent workflows"
+      "Loss of visibility: harder to track what's happening",
+      "Integration challenges: existing tools don't fit new model",
+      "Team resistance: developers attached to familiar workflows",
+      "New risks: more automation means blast radius increases",
+      "Transition pain: hybrid human/agent workflows are awkward"
     ],
     "ko": [
-      "진행 상황에 대한 가시성 손실",
-      "기존 도구와의 통합 문제",
-      "익숙하지 않은 워크플로우에 대한 팀의 저항",
-      "더 많은 자동화에 따른 영향 범위 증가",
-      "하이브리드 인간/에이전트 워크플로우의 전환 고통"
+      "가시성 손실: 진행 상황 추적이 어려움",
+      "통합 문제: 기존 도구가 새 모델에 맞지 않음",
+      "팀 저항: 개발자가 익숙한 워크플로우에 집착",
+      "새로운 위험: 자동화 증가로 영향 범위 확대",
+      "전환 고통: 하이브리드 인간/에이전트 워크플로우의 어색함"
     ]
   },
-  "mermaid_diagram": "graph TD\n    A1[Humans write code] --> C[Linear Tickets]\n    A2[Code is scarce] --> D[PR Reviews]\n    A3[Developers are busy] --> E[Sprint Planning]\n    B1[Agents write code] --> G[Send Agent Immediately]\n    B2[Code is abundant] --> H[Generate 10 Variations]\n    B3[Agents are unlimited] --> I[Parallel Investigation]",
-  "tags": ["dev-tools", "assumptions", "tickets", "code-review", "tooling", "agent-workflows", "paradigm-shift"]
+  "mermaid_diagram": "graph TD\n    subgraph Old_Assumptions[\"Old Assumptions\"]\n        A1[Humans write code]\n        A2[Code is scarce/valuable]\n        A3[Developers are busy]\n        A4[Changes are permanent]\n    end\n\n    subgraph New_Reality[\"New Reality\"]\n        B1[Agents write code]\n        B2[Code is abundant/cheap]\n        B3[Agents are unlimited]\n        B4[Variations are trivial]\n    end\n\n    A1 --> C[Linear Tickets]\n    A2 --> D[PR Reviews + Emoji Reactions]\n    A3 --> E[Sprint Planning]\n    A4 --> F[Branching Strategies]\n\n    B1 --> G[Send Agent Immediately]\n    B2 --> H[Generate 10 Variations]\n    B3 --> I[Parallel Investigation]\n    B4 --> J[Primordial Soup]",
+  "tags": ["dev-tools", "assumptions", "github", "tickets", "code-review", "tooling", "agent-workflows", "paradigm-shift"]
 }

--- a/src/data/patterns/frontier-focused-development.json
+++ b/src/data/patterns/frontier-focused-development.json
@@ -6,55 +6,61 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=2wjnV6F2arc",
   "problem": {
-    "en": "AI capabilities are advancing so rapidly that products optimized for today's models will be obsolete in months. Many teams waste time solving problems that new models already solve, or build products tied to specific models that won't stay competitive.",
-    "ko": "AI 능력이 매우 빠르게 발전하여 오늘의 모델에 최적화된 제품은 몇 달 안에 구식이 됩니다. 많은 팀이 새 모델이 이미 해결하는 문제를 해결하느라 시간을 낭비하거나, 경쟁력을 유지하지 못할 특정 모델에 묶인 제품을 만듭니다."
+    "en": "AI capabilities advance rapidly along predictable scaling laws—products optimized for today's models become obsolete in months. Many teams waste time solving problems that frontier models already solve, or build products tied to specific models that won't stay competitive.",
+    "ko": "AI 능력은 예측 가능한 스케일링 법칙에 따라 빠르게 발전하여, 오늘의 모델에 최적화된 제품은 몇 달 안에 구식이 됩니다. 많은 팀이 프론티어 모델이 이미 해결하는 문제를 해결하느라 시간을 낭비하거나, 경쟁력을 유지하지 못할 특정 모델에 묶인 제품을 만듭니다."
   },
   "solution": {
-    "en": "Always target the frontier—the state-of-the-art models—and design products that can rapidly evolve. Key principles: no model selector (pick the best model per use case), frontier or nothing (only build features that push boundaries), rapid evolution (expect complete product changes every 3 months), and avoid subscription tie-ins to specific models.",
-    "ko": "항상 프론티어(최첨단 모델)를 목표로 하고 빠르게 진화할 수 있는 제품을 설계합니다. 핵심 원칙: 모델 선택기 없이(사용 사례별 최적 모델 선택), 프론티어 아니면 하지 않기(경계를 넓히는 기능만 구축), 빠른 진화(3개월마다 제품 완전 변경 예상), 특정 모델에 대한 구독 종속 회피입니다."
+    "en": "**Always target the frontier**—the state-of-the-art models—and design products that can rapidly evolve as the frontier moves. Don't optimize for older, cheaper models, and don't offer model selectors that trap users in the past.\n\n**Core principles:**\n\n1. **No model selector**: Pick the best model for each use case, don't let users choose\n2. **Frontier or nothing**: Only build features that push boundaries and generate learning\n3. **Rapid evolution**: Expect to completely change your product every 3 months (AI product lifecycle research confirms quarterly cycles are necessary to remain competitive)\n4. **Subscription resistance**: Avoid being tied to one model's pricing structure\n\n**The problem with optimizing for cost:**\n\nEmergent abilities research shows some capabilities appear suddenly at scale and cannot be predicted or engineered around in smaller models. Cost optimization against today's models solves problems that frontier models will soon solve inherently.\n\n**Why no model selector?**\n\n1. **Learning**: Can't learn how users interact if everyone uses different models (research shows focused single-model products learn faster)\n2. **Focus**: One way to use the product means everyone benefits from improvements\n3. **Evolution**: Not beholden to models that were popular 3-6 months ago\n4. **Quality**: Can optimize specifically for the best model's capabilities\n\n**The risk of subscription models:**\n\nWhen you offer a subscription (like Claude Max), you become tied to that model:\n- Can't switch if a better model emerges\n- Price changes become user-hostile\n- Roadmap decisions dictated by one company",
+    "ko": "**항상 프론티어를 목표로** 합니다—최첨단 모델을 타겟으로 하고, 프론티어가 이동함에 따라 빠르게 진화할 수 있는 제품을 설계합니다. 구형의 저렴한 모델에 최적화하거나, 사용자를 과거에 가두는 모델 선택기를 제공하지 않습니다.\n\n**핵심 원칙:**\n\n1. **모델 선택기 없음**: 사용 사례별 최적 모델을 선택하고, 사용자에게 선택권을 주지 않습니다\n2. **프론티어 아니면 하지 않기**: 경계를 넓히고 학습을 생성하는 기능만 구축합니다\n3. **빠른 진화**: 3개월마다 제품을 완전히 변경할 것을 예상합니다 (AI 제품 수명주기 연구에서 분기별 주기가 경쟁력 유지에 필요하다고 확인)\n4. **구독 저항**: 하나의 모델 가격 구조에 묶이는 것을 피합니다\n\n**비용 최적화의 문제:**\n\n창발적 능력 연구에 따르면 일부 능력은 스케일에서 갑자기 나타나며, 작은 모델에서 예측하거나 우회할 수 없습니다. 오늘의 모델에 대한 비용 최적화는 프론티어 모델이 곧 본질적으로 해결할 문제를 해결하는 것입니다.\n\n**모델 선택기가 없는 이유:**\n\n1. **학습**: 모든 사용자가 다른 모델을 사용하면 사용자 상호작용을 학습할 수 없습니다\n2. **집중**: 제품 사용 방식이 하나이면 모든 사용자가 개선의 혜택을 받습니다\n3. **진화**: 3~6개월 전에 인기 있던 모델에 종속되지 않습니다\n4. **품질**: 최고 모델의 능력에 특화하여 최적화할 수 있습니다\n\n**구독 모델의 위험:**\n\n구독(예: Claude Max)을 제공하면 해당 모델에 묶이게 됩니다:\n- 더 나은 모델이 나와도 전환 불가\n- 가격 변경이 사용자에게 적대적으로 작용\n- 로드맵 결정이 한 회사에 의해 좌우"
   },
   "when_to_use": {
     "en": [
       "Targeting early adopters and frontier users",
-      "Products where AI capability is the core differentiator",
+      "Building for developers who value speed over cost",
       "Small teams that can pivot quickly",
-      "Building for developers who value speed over cost"
+      "Products where AI capability is the core differentiator",
+      "Users who want to be on the cutting edge"
     ],
     "ko": [
       "얼리 어답터와 프론티어 사용자를 타겟으로 할 때",
-      "AI 능력이 핵심 차별화 요소인 제품",
+      "비용보다 속도를 중시하는 개발자를 위한 제품",
       "빠르게 방향 전환할 수 있는 소규모 팀",
-      "비용보다 속도를 중시하는 개발자를 위한 제품"
+      "AI 능력이 핵심 차별화 요소인 제품",
+      "최첨단에 있고 싶은 사용자"
     ]
   },
   "pros": {
     "en": [
-      "Always at the frontier as models improve",
-      "Rapid learning from focused usage",
-      "Future-proof with instant model switching capability",
-      "Quality focus on best capabilities"
+      "Always at the frontier: your product improves as models improve",
+      "Rapid learning: focused usage generates clear insights",
+      "Future-proof: can switch models instantly when something better emerges",
+      "Quality focus: optimize for best capabilities, not lowest common denominator",
+      "Innovation: positioned to discover what's possible with frontier models"
     ],
     "ko": [
-      "모델 개선에 따라 항상 프론티어 유지",
-      "집중된 사용에서의 빠른 학습",
-      "즉각적 모델 전환 기능으로 미래 대비",
-      "최고 기능에 대한 품질 집중"
+      "항상 프론티어 유지: 모델이 개선되면 제품도 개선",
+      "빠른 학습: 집중된 사용이 명확한 인사이트 생성",
+      "미래 대비: 더 나은 모델이 나오면 즉시 전환 가능",
+      "품질 집중: 최저 공통분모가 아닌 최고 능력에 최적화",
+      "혁신: 프론티어 모델로 가능한 것을 발견할 위치 확보"
     ]
   },
   "cons": {
     "en": [
-      "Higher costs with frontier models",
-      "Smaller market excluding cost-sensitive users",
-      "Rapid product changes every 3 months",
-      "Exclusionary to 'median' users wanting stability"
+      "Higher costs: frontier models are more expensive (for now)",
+      "Smaller market: some users won't pay for frontier performance",
+      "Rapid change: product may look completely different in 3 months",
+      "Exclusionary: not building for 'median' users who want stability",
+      "Uncertainty: constantly reinventing rather than stabilizing"
     ],
     "ko": [
-      "프론티어 모델의 높은 비용",
-      "비용 민감 사용자를 제외한 작은 시장",
-      "3개월마다 급격한 제품 변경",
-      "안정성을 원하는 '중간' 사용자에게 배타적"
+      "높은 비용: 프론티어 모델이 더 비쌈 (현재로서는)",
+      "작은 시장: 일부 사용자는 프론티어 성능에 비용을 지불하지 않음",
+      "급격한 변화: 3개월 후 제품이 완전히 달라질 수 있음",
+      "배타적: 안정성을 원하는 '중간' 사용자를 위해 구축하지 않음",
+      "불확실성: 안정화보다 끊임없는 재발명"
     ]
   },
-  "mermaid_diagram": "graph TD\n    A[New Model Released] --> B{At the Frontier?}\n    B -->|Yes| C[Adopt Immediately]\n    B -->|No, Older| D[Ignore]\n    C --> E[Learn from Usage]\n    E --> F[Product Evolves]\n    F --> A\n    D --> G[Wasted Effort]\n    G --> H[Stale Product]",
-  "tags": ["frontier", "state-of-the-art", "model-selection", "product-strategy", "learning", "innovation"]
+  "mermaid_diagram": "graph TD\n    A[New Model Released] --> B{At the Frontier?}\n    B -->|Yes| C[Adopt Immediately]\n    B -->|No, Cheaper/Older| D[Ignore - Will Be Obsolete]\n\n    C --> E[Learn from Usage]\n    E --> F[Product Evolves]\n    F --> A\n\n    D --> G[Wasted Effort]\n    G --> H[Stale Product in 6 Months]",
+  "tags": ["frontier", "state-of-the-art", "model-selection", "product-strategy", "learning", "innovation", "no-selector"]
 }

--- a/src/data/patterns/semantic-context-filtering.json
+++ b/src/data/patterns/semantic-context-filtering.json
@@ -6,27 +6,61 @@
   "status": "emerging",
   "original_url": "https://github.com/hyperbrowserai/HyperAgent",
   "problem": {
-    "en": "Raw data sources are too verbose and noisy for effective LLM consumption, wasting tokens and confusing reasoning.",
-    "ko": "원시 데이터 소스가 LLM이 효과적으로 소비하기에 너무 장황하고 노이즈가 많아 토큰을 낭비하고 추론을 혼란스럽게 합니다."
+    "en": "Raw data sources are too verbose and noisy for effective LLM consumption. Full representations include invisible elements, implementation details, and irrelevant information that bloat context and confuse reasoning. Research on boilerplate detection shows that 40-80% of web page content is typically navigation, footers, ads, and other boilerplate that should be filtered before semantic processing. This creates several problems: token explosion where raw data exceeds context limits or becomes prohibitively expensive, poor signal-to-noise where LLM wastes reasoning capacity on irrelevant details, slower inference with more tokens meaning slower generation and higher costs, and confused reasoning where noise leads to hallucinations or wrong conclusions. The issue appears across domains including web scraping (full HTML DOM with scripts, styles, tracking iframes), API responses (JSON with nested metadata, internal fields, debug info), document processing (headers, footers, navigation, boilerplate text), and code analysis (comments, whitespace, boilerplate code).",
+    "ko": "원시 데이터 소스가 LLM이 효과적으로 소비하기에 너무 장황하고 노이즈가 많습니다. 전체 표현에는 보이지 않는 요소, 구현 세부사항, 관련 없는 정보가 포함되어 컨텍스트를 부풀리고 추론을 혼란스럽게 합니다. 보일러플레이트 탐지 연구에 따르면 웹 페이지 콘텐츠의 40-80%가 일반적으로 내비게이션, 푸터, 광고 및 의미론적 처리 전에 필터링해야 하는 기타 보일러플레이트입니다. 이로 인해 여러 문제가 발생합니다: 원시 데이터가 컨텍스트 제한을 초과하거나 비용이 과도해지는 토큰 폭발, LLM이 관련 없는 세부사항에 추론 능력을 낭비하는 낮은 신호 대 노이즈 비, 더 많은 토큰으로 인한 느린 추론과 높은 비용, 노이즈가 환각이나 잘못된 결론으로 이어지는 혼란스러운 추론이 있습니다. 이 문제는 웹 스크래핑(스크립트, 스타일, 추적 iframe이 포함된 전체 HTML DOM), API 응답(중첩된 메타데이터, 내부 필드, 디버그 정보가 있는 JSON), 문서 처리(헤더, 푸터, 내비게이션, 보일러플레이트 텍스트), 코드 분석(주석, 공백, 보일러플레이트 코드) 등 여러 도메인에 걸쳐 나타납니다."
   },
   "solution": {
-    "en": "Extract only semantic, interactive, or relevant elements from raw data, providing clean abstractions to the LLM.",
-    "ko": "원시 데이터에서 의미론적, 대화형 또는 관련 요소만 추출하여 LLM에 깨끗한 추상화를 제공합니다."
+    "en": "Extract only the semantic, interactive, or relevant elements from raw data. Filter out noise and provide the LLM with a clean representation that captures what matters for reasoning.\n\n**Core Principle: Don't send raw data to the LLM. Send semantic abstractions.**\n\nThis approach is validated across production systems including browser automation tools (Puppeteer/Playwright accessibility trees), RAG frameworks (LangChain, LlamaIndex semantic chunking), and code analysis tools (Aider's AST-based repo-map).\n\nKey techniques:\n1. **Browser Accessibility Tree**: Extract interactive elements only (100-200 tokens vs 10,000+ tokens for full HTML)\n2. **API Response Filtering**: Strip internal metadata, debug info, and internal fields to keep only business data\n3. **Document Section Extraction**: Skip headers, footers, navigation, legal disclaimers to keep only actual content (~20% of original size)\n4. **Maintain Reference Mapping**: Keep filtered-to-original mappings for execution",
+    "ko": "원시 데이터에서 의미론적, 대화형 또는 관련 요소만 추출합니다. 노이즈를 필터링하고 추론에 중요한 것을 포착하는 깨끗한 표현을 LLM에 제공합니다.\n\n**핵심 원칙: 원시 데이터를 LLM에 보내지 마십시오. 의미론적 추상화를 보내십시오.**\n\n이 접근 방식은 브라우저 자동화 도구(Puppeteer/Playwright 접근성 트리), RAG 프레임워크(LangChain, LlamaIndex 의미론적 청킹), 코드 분석 도구(Aider의 AST 기반 repo-map)를 포함한 프로덕션 시스템에서 검증되었습니다.\n\n핵심 기법:\n1. **브라우저 접근성 트리**: 대화형 요소만 추출 (전체 HTML의 10,000+ 토큰 대비 100-200 토큰)\n2. **API 응답 필터링**: 내부 메타데이터, 디버그 정보, 내부 필드를 제거하고 비즈니스 데이터만 유지\n3. **문서 섹션 추출**: 헤더, 푸터, 내비게이션, 법적 면책 조항을 건너뛰고 실제 콘텐츠만 유지 (원본 크기의 약 20%)\n4. **참조 매핑 유지**: 실행을 위한 필터링-원본 매핑 유지"
   },
   "ascii_diagram": "┌─────────────┐\n│ Raw HTML    │\n│ (10K tokens)│\n└──────┬──────┘\n       │ filter\n┌──────▼──────┐\n│ Accessibility│\n│    Tree     │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│ Clean JSON  │\n│ (200 tokens)│\n└─────────────┘",
   "mermaid_diagram": "flowchart LR\n    A[Raw Data Source] --> B[Semantic Filter]\n    B --> C[Interactive Elements]\n    B --> D[Relevant Fields]\n    B --> E[Content Sections]\n    C & D & E --> F[Clean Context for LLM]",
   "code_example": "# Instead of full HTML DOM (10,000+ tokens)\n# Extract accessibility tree (100-200 tokens)\ntree = await page.accessibility.snapshot(\n    interestingOnly=True  # Only interactive elements\n)\n\n# Result: Clean semantic representation\n# {\n#   \"role\": \"button\",\n#   \"name\": \"Login\",\n#   \"xpath\": \"/html/body/main/button\"\n# }",
   "when_to_use": {
-    "en": ["Web scraping agents", "Document processing", "API response handling"],
-    "ko": ["웹 스크래핑 에이전트", "문서 처리", "API 응답 처리"]
+    "en": [
+      "Identify semantic elements for your domain (web: interactive elements, API: business data, documents: content sections)",
+      "Build a filter layer that extracts only relevant data",
+      "Apply filtering before every LLM call",
+      "Maintain reference mapping from filtered to original data for execution"
+    ],
+    "ko": [
+      "도메인에 맞는 의미론적 요소 식별 (웹: 대화형 요소, API: 비즈니스 데이터, 문서: 콘텐츠 섹션)",
+      "관련 데이터만 추출하는 필터 계층 구축",
+      "모든 LLM 호출 전에 필터링 적용",
+      "실행을 위한 필터링-원본 데이터 참조 매핑 유지"
+    ]
   },
   "pros": {
-    "en": ["10-100x token reduction", "Better LLM reasoning", "Lower costs and latency"],
-    "ko": ["10-100배 토큰 감소", "더 나은 LLM 추론", "낮은 비용과 지연"]
+    "en": [
+      "Dramatic token reduction: 10-100x smaller context",
+      "Better LLM reasoning: Focus on signal, not noise",
+      "Lower costs: Fewer tokens = cheaper",
+      "Faster inference: Smaller context = faster generation",
+      "Higher reliability: Less confusion and hallucination"
+    ],
+    "ko": [
+      "극적인 토큰 감소: 10-100배 더 작은 컨텍스트",
+      "더 나은 LLM 추론: 노이즈가 아닌 신호에 집중",
+      "비용 절감: 적은 토큰 = 저렴한 비용",
+      "빠른 추론: 작은 컨텍스트 = 빠른 생성",
+      "높은 신뢰성: 혼란과 환각 감소"
+    ]
   },
   "cons": {
-    "en": ["Filter complexity", "Potential information loss", "Domain-specific filters needed"],
-    "ko": ["필터 복잡성", "잠재적 정보 손실", "도메인별 필터 필요"]
+    "en": [
+      "Filter complexity: Need to build and maintain filter logic",
+      "Information loss: May remove context that matters",
+      "Domain-specific: Filters need to be tailored per use case",
+      "Mapping overhead: Need to track filtered-to-original references",
+      "Potential bugs: Filter might remove important elements"
+    ],
+    "ko": [
+      "필터 복잡성: 필터 로직 구축 및 유지 필요",
+      "정보 손실: 중요한 컨텍스트를 제거할 수 있음",
+      "도메인 특화: 사용 사례별 필터 맞춤 필요",
+      "매핑 오버헤드: 필터링-원본 참조 추적 필요",
+      "잠재적 버그: 필터가 중요한 요소를 제거할 수 있음"
+    ]
   },
   "tags": ["context-filtering", "token-optimization", "semantic-extraction", "noise-reduction"]
 }

--- a/src/data/patterns/stop-hook-auto-continue-pattern.json
+++ b/src/data/patterns/stop-hook-auto-continue-pattern.json
@@ -6,27 +6,65 @@
   "status": "emerging",
   "original_url": "https://every.to/podcast/transcript-how-to-use-claude-code-like-the-people-who-built-it",
   "problem": {
-    "en": "Agents may stop prematurely before completing all requirements, claiming they're done when they're not.",
-    "ko": "에이전트가 모든 요구사항을 완료하기 전에 조기에 중지하고, 완료되지 않았는데 완료됐다고 주장할 수 있습니다."
+    "en": "Agents complete their turn and return control to the user even when the task isn't truly done. Common scenarios include: code compiles but tests fail, changes made but quality checks haven't passed, feature implemented but integration tests broken, and migrations run but verification steps not completed. Without intervention, the user must manually check and re-prompt the agent, creating friction.",
+    "ko": "에이전트가 작업이 실제로 완료되지 않았는데도 턴을 완료하고 사용자에게 제어를 반환합니다. 일반적인 시나리오로는 코드는 컴파일되지만 테스트가 실패하거나, 변경이 이루어졌지만 품질 검사를 통과하지 못했거나, 기능은 구현되었지만 통합 테스트가 깨져 있거나, 마이그레이션은 실행되었지만 검증 단계가 완료되지 않은 경우가 있습니다. 개입 없이는 사용자가 수동으로 확인하고 에이전트에 다시 프롬프트를 보내야 하며, 이는 마찰을 유발합니다."
   },
   "solution": {
-    "en": "Use stop hooks to verify success criteria (tests pass, lint clean) before allowing agent termination.",
-    "ko": "에이전트 종료를 허용하기 전에 성공 기준(테스트 통과, 린트 클린)을 확인하는 정지 훅을 사용합니다."
+    "en": "Use **stop hooks** to programmatically check success criteria after each agent turn. If criteria aren't met, automatically continue the agent's execution until the task is genuinely complete.\n\n**Stop hook**: A script that runs when the agent finishes a turn. It can inspect state and decide whether to return control to the user or keep the agent running.\n\n```pseudo\ndefine_stop_hook() {\n    test_result = run_tests()\n    if test_result.failed:\n        agent.continue_with_prompt(\n            \"Tests failed with: {test_result.errors}. Fix these issues.\"\n        )\n    else:\n        agent.stop()  // Return control to user\n}\n```\n\n**Combined with dangerous mode**: In containerized/sandboxed environments, this enables fully autonomous operation until success.",
+    "ko": "**정지 훅**을 사용하여 각 에이전트 턴 후 성공 기준을 프로그래밍 방식으로 확인합니다. 기준이 충족되지 않으면 작업이 진정으로 완료될 때까지 에이전트의 실행을 자동으로 계속합니다.\n\n**정지 훅**: 에이전트가 턴을 마칠 때 실행되는 스크립트입니다. 상태를 검사하고 사용자에게 제어를 반환할지 에이전트를 계속 실행할지 결정할 수 있습니다.\n\n**위험 모드와 결합**: 컨테이너화/샌드박스 환경에서 성공할 때까지 완전 자율 운영을 가능하게 합니다."
   },
   "ascii_diagram": "┌─────────────┐\n│   Agent     │\n│  \"Done\"     │\n└──────┬──────┘\n       │\n┌──────▼──────┐\n│  Stop Hook  │\n│  Check:     │\n│  - Tests?   │\n│  - Lint?    │\n└──────┬──────┘\n   ┌───┴───┐\n   ▼       ▼\n [Pass]  [Fail]\n   │       │\n   ▼  ┌────▼────┐\n Done │Continue │\n      │ Working │\n      └─────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Agent: I'm Done] --> B{Stop Hook Check}\n    B -->|Tests Pass & Lint Clean| C[Really Done]\n    B -->|Failures Found| D[Continue Working]\n    D --> A",
   "code_example": "# Claude Code stop hook example\n# .claude/hooks/stop.sh\n#!/bin/bash\nnpm test || exit 1  # Fails = agent continues\nnpm run lint || exit 1\necho 'All checks passed'",
   "when_to_use": {
-    "en": ["Test-driven development", "Quality gates", "Autonomous agents"],
-    "ko": ["테스트 주도 개발", "품질 게이트", "자율 에이전트"]
+    "en": [
+      "Define success criteria (tests pass, build succeeds, linter clean, etc.)",
+      "Create stop hook that checks these criteria",
+      "If criteria fail, inject feedback and continue agent execution",
+      "If criteria pass, return control to user",
+      "Combine with dangerous mode in containers for autonomous operation",
+      "Achieve deterministic outcomes from non-deterministic processes"
+    ],
+    "ko": [
+      "성공 기준 정의 (테스트 통과, 빌드 성공, 린터 클린 등)",
+      "성공 기준을 확인하는 정지 훅 생성",
+      "기준 실패 시 피드백 주입 및 에이전트 실행 계속",
+      "기준 통과 시 사용자에게 제어 반환",
+      "컨테이너에서 위험 모드와 결합하여 자율 운영",
+      "비결정적 프로세스에서 결정적 결과 달성"
+    ]
   },
   "pros": {
-    "en": ["Completion guarantee", "Quality maintenance", "Automation"],
-    "ko": ["완료 보장", "품질 유지", "자동화"]
+    "en": [
+      "True task completion: Don't stop until actually done",
+      "Reduced human intervention: No manual re-prompting needed",
+      "Systematic quality: Encoded success criteria, not human judgment",
+      "Autonomous operation: Combined with SDK, enables fully hands-off tasks",
+      "Prevents premature completion: Agent can't declare victory too early"
+    ],
+    "ko": [
+      "진정한 작업 완료: 실제로 완료될 때까지 중지하지 않음",
+      "인간 개입 감소: 수동 재프롬프트 불필요",
+      "체계적 품질: 인간 판단이 아닌 인코딩된 성공 기준",
+      "자율 운영: SDK와 결합하여 완전 비대면 작업 가능",
+      "조기 완료 방지: 에이전트가 너무 일찍 승리를 선언할 수 없음"
+    ]
   },
   "cons": {
-    "en": ["Risk of infinite loops", "Hook design required"],
-    "ko": ["무한 루프 위험", "훅 설계 필요"]
+    "en": [
+      "Runaway costs: Agent might loop indefinitely if criteria impossible",
+      "Requires good criteria: Bad success checks lead to infinite loops",
+      "Container overhead: Safest in sandboxed environments",
+      "Debugging challenges: Harder to inspect mid-execution state",
+      "Timeout management: Need sensible limits to prevent infinite execution"
+    ],
+    "ko": [
+      "비용 폭주: 기준이 불가능하면 에이전트가 무한 루프에 빠질 수 있음",
+      "좋은 기준 필요: 잘못된 성공 검사는 무한 루프로 이어짐",
+      "컨테이너 오버헤드: 샌드박스 환경에서 가장 안전",
+      "디버깅 어려움: 실행 중간 상태 검사가 어려움",
+      "타임아웃 관리: 무한 실행 방지를 위한 합리적 제한 필요"
+    ]
   },
-  "tags": ["hooks", "automation", "testing", "success-criteria", "quality-gates"]
+  "tags": ["hooks", "automation", "testing", "determinism", "success-criteria", "continuous-execution"]
 }


### PR DESCRIPTION
## Summary
이슈 #49의 Batch 11 - 변경 규모 101-110위 10개 패턴 업데이트.

## Test plan
- [x] `npm test` 로컬 통과

Part of #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)