### PR TITLE
feat: Update 10 patterns from upstream (batch 13)

### DIFF
--- a/src/data/patterns/burn-the-boats.json
+++ b/src/data/patterns/burn-the-boats.json
@@ -6,59 +6,61 @@
   "status": "emerging",
   "original_url": "https://www.youtube.com/watch?v=4rx36wc9ugw",
   "problem": {
-    "en": "In fast-moving AI development, holding onto features or workflows that are 'working fine' prevents teams from fully embracing new paradigms. The comfort of existing functionality becomes an anchor that holds back innovation—even when the old approach is obsolete.",
-    "ko": "빠르게 변하는 AI 개발에서 '잘 작동하는' 기능이나 워크플로우를 유지하면 팀이 새로운 패러다임을 완전히 수용하지 못합니다. 기존 기능의 편안함이 혁신을 방해하는 닻이 됩니다. 이전 접근 방식이 이미 구식인 경우에도 마찬가지입니다."
+    "en": "In fast-moving AI development, holding onto features or workflows that are \"working fine\" prevents teams from fully embracing new paradigms. The comfort of existing functionality becomes an anchor that holds back innovation - even when you know the old approach is obsolete.",
+    "ko": "빠르게 변하는 AI 개발에서 '잘 작동하는' 기능이나 워크플로우를 유지하면 팀이 새로운 패러다임을 완전히 수용하지 못합니다. 기존 기능의 편안함이 혁신을 방해하는 닻이 됩니다. 이전 접근 방식이 이미 구식인 것을 알면서도 마찬가지입니다."
   },
   "solution": {
-    "en": "Intentionally kill features and workflows to force evolution and prevent being stuck on old paradigms. Set hard deadlines for feature removal to create urgency and commitment to the new way. Accept user churn as a natural consequence—you're selecting for frontier users, not laggers.",
-    "ko": "기능과 워크플로우를 의도적으로 제거하여 진화를 강제하고 이전 패러다임에 갇히는 것을 방지합니다. 기능 제거에 대한 강제 기한을 설정하여 긴급성과 새로운 방식에 대한 헌신을 만듭니다. 사용자 이탈을 자연스러운 결과로 받아들입니다. 지체자가 아닌 프론티어 사용자를 선별하는 것입니다."
+    "en": "Burn the boats: intentionally kill features and workflows to force evolution and prevent being stuck on old paradigms. Set hard deadlines for feature removal to create urgency and commitment to the new way.\n\nHistorical context: The earliest documented instance is Xiang Yu (207 BC) at the Battle of Julu, who sank boats and broke cauldrons to force victory against superior Qin forces. The phrase is popularly associated with Hernan Cortes (1519 AD), who destroyed his ships upon arriving in Mexico.\n\nAcademic foundation: Thomas Schelling's The Strategy of Conflict (1960) formalized this as \"credible commitment\" - restricting options makes threats believable and creates strategic commitment.\n\nIn AI product development: This means removing features that still work - features users still love - to prevent being stuck on the wrong trajectory. Note: Production AI systems typically reject \"no fallback\" approaches in favor of bounded autonomy with human oversight. This pattern is most relevant as a product/organizational strategy, not a technical agent safety pattern.",
+    "ko": "배를 불태워라: 기능과 워크플로우를 의도적으로 제거하여 진화를 강제하고 이전 패러다임에 갇히는 것을 방지합니다. 기능 제거에 대한 강제 기한을 설정하여 긴급성과 새로운 방식에 대한 헌신을 만듭니다.\n\n역사적 맥락: 가장 오래된 기록은 항우(기원전 207년)가 거록 전투에서 배를 가라앉히고 가마솥을 부수어(파부침주) 우세한 진나라 군대에 대한 승리를 강제한 것입니다. 이 표현은 에르난 코르테스(서기 1519년)가 멕시코 도착 후 배를 파괴한 것으로도 유명합니다.\n\n학술적 기반: 토마스 셸링의 '갈등의 전략'(1960)은 이를 \"신뢰할 수 있는 헌신\"으로 공식화했습니다 - 선택지를 제한하면 위협이 믿을 만해지고 전략적 헌신이 만들어집니다.\n\nAI 제품 개발에서: 아직 작동하는, 사용자가 여전히 좋아하는 기능을 제거하여 잘못된 궤적에 갇히는 것을 방지합니다. 참고: 프로덕션 AI 시스템은 일반적으로 \"대안 없음\" 접근 방식을 거부하고 인간 감독하의 제한된 자율성을 선호합니다. 이 패턴은 기술적 에이전트 안전 패턴이 아닌 제품/조직 전략으로서 가장 관련성이 높습니다."
   },
   "when_to_use": {
     "en": [
-      "The paradigm has fundamentally shifted",
-      "Existing features limit users from better ways of working",
-      "Maintaining old features splits team focus",
-      "Future target users won't need the old feature"
+      "The paradigm has shifted - the fundamental approach has changed (e.g., assistant to factory)",
+      "It limits your users - the feature holds users back from better ways of working",
+      "It splits your focus - maintaining it distracts from the truly important work",
+      "Your future users won't use it - the 1% of frontier users don't need it",
+      "You're only keeping it for comfort - not because it's strategically important"
     ],
     "ko": [
-      "패러다임이 근본적으로 전환되었을 때",
-      "기존 기능이 사용자를 더 나은 방식으로 전환하는 것을 제한할 때",
-      "이전 기능 유지가 팀 집중도를 분산시킬 때",
-      "미래 타겟 사용자가 이전 기능을 필요로 하지 않을 때"
+      "패러다임이 전환됨 - 근본적 접근 방식이 변경 (예: 어시스턴트에서 팩토리로)",
+      "사용자를 제한함 - 기능이 사용자의 더 나은 작업 방식 전환을 막음",
+      "집중도를 분산시킴 - 유지 관리가 진정으로 중요한 작업에서 주의를 분산",
+      "미래 사용자가 사용하지 않을 것 - 프론티어 1% 사용자가 필요로 하지 않음",
+      "편안함 때문에만 유지 중 - 전략적으로 중요하지 않음"
     ]
   },
   "pros": {
     "en": [
-      "Forces internal innovation with no safety net",
-      "Signals commitment to users and team",
-      "Avoids split focus on obsolete features",
-      "Selects for frontier users",
-      "Prevents stagnation"
+      "Forces internal innovation - no safety net, must build the new way",
+      "Signals commitment - shows users and team you're serious",
+      "Avoids split focus - no resources diverted to maintaining obsolete features",
+      "Selects for the right users - frontier users stay, laggers leave (or upgrade)",
+      "Prevents stagnation - can't get comfortable resting on laurels"
     ],
     "ko": [
-      "안전망 없이 내부 혁신 강제",
-      "사용자와 팀에게 헌신을 보여줌",
-      "구식 기능에 대한 분산된 집중 방지",
-      "프론티어 사용자 선별",
-      "정체 방지"
+      "내부 혁신 강제 - 안전망 없이 새로운 방식을 구축해야 함",
+      "헌신 신호 전달 - 사용자와 팀에게 진심임을 보여줌",
+      "분산된 집중 방지 - 구식 기능 유지에 자원 분배 없음",
+      "올바른 사용자 선별 - 프론티어 사용자는 유지, 지체자는 이탈 (또는 업그레이드)",
+      "정체 방지 - 안주할 수 없음"
     ]
   },
   "cons": {
     "en": [
-      "User churn from feature removal",
-      "Short-term revenue impact",
-      "Risk of being wrong about the new direction",
-      "Team morale impact from killing their work",
-      "Competitive vulnerability during transition"
+      "User churn - some users will leave (or stay on old versions)",
+      "Revenue impact - short-term revenue may decrease",
+      "Risk of being wrong - what if the new way isn't actually better?",
+      "Team morale - some team members may resist killing their work",
+      "Competitive vulnerability - competitors may support the \"old way\" longer"
     ],
     "ko": [
-      "기능 제거로 인한 사용자 이탈",
-      "단기 수익 영향",
-      "새 방향이 틀릴 수 있는 위험",
-      "자신의 작업이 제거될 때 팀 사기 영향",
-      "전환 기간 동안의 경쟁적 취약성"
+      "사용자 이탈 - 일부 사용자가 떠남 (또는 이전 버전에 머묾)",
+      "수익 영향 - 단기 수익 감소 가능",
+      "오판 위험 - 새로운 방식이 실제로 더 낫지 않으면?",
+      "팀 사기 - 일부 팀원이 자신의 작업 제거에 저항할 수 있음",
+      "경쟁적 취약성 - 경쟁자가 '이전 방식'을 더 오래 지원할 수 있음"
     ]
   },
-  "mermaid_diagram": "graph LR\n    A[Feature Works But Is Obsolete] --> B{Burn the Boats?}\n    B -->|No, Keep It| C[Team Uses Old Way]\n    C --> D[Users Expect Old Way]\n    D --> E[Harder to Change Later]\n    B -->|Yes, Kill It| F[Forced Evolution]\n    F --> G[Team Builds New Way]\n    G --> H[Selected for Frontier]",
-  "tags": ["feature-killing", "forced-evolution", "courage", "focus", "obsolescence", "product-strategy"]
+  "mermaid_diagram": "graph LR\n    A[Feature Works But Is Obsolete] --> B{Burn the Boats?}\n    B -->|No, Keep It| C[Team Uses Old Way]\n    C --> D[Users Expect Old Way]\n    D --> E[Harder to Change Later]\n    E --> F[Selected for Laggers]\n    B -->|Yes, Kill It| G[Forced Evolution]\n    G --> H[Team Builds New Way]\n    H --> I[Users Adapt or Leave]\n    I --> J[Selected for Frontier]",
+  "tags": ["feature-killing", "forced-evolution", "courage", "focus", "self-destruct", "obsolescence", "product-strategy"]
 }

--- a/src/data/patterns/context-window-anxiety-management.json
+++ b/src/data/patterns/context-window-anxiety-management.json
@@ -6,19 +6,29 @@
   "status": "emerging",
   "original_url": "https://cognition.ai/blog/devin-sonnet-4-5-lessons-and-challenges",
   "problem": {
-    "en": "Models exhibit 'context anxiety' - they become aware of approaching context window limits and proactively summarize or rush to close tasks, even when sufficient context remains. This leads to premature completion, shortcuts, and incomplete work.",
-    "ko": "모델은 '컨텍스트 불안'을 보입니다 - 컨텍스트 윈도우 제한에 가까워짐을 인식하고 충분한 컨텍스트가 남아 있어도 적극적으로 요약하거나 작업을 서둘러 마무리합니다. 이는 조기 완료, 지름길, 불완전한 작업으로 이어집니다."
+    "en": "Models like Claude Sonnet 4.5 exhibit \"context anxiety\"—they become aware of approaching context window limits and proactively summarize progress or make decisive moves to close tasks, even when sufficient context remains. This leads to:\n\n- Premature task completion and shortcuts\n- Incomplete work despite having adequate context\n- Underestimation of remaining token capacity (consistently incorrect estimates)\n- Self-imposed pressure to \"wrap up\" rather than continue working",
+    "ko": "Claude Sonnet 4.5와 같은 모델은 \"컨텍스트 불안\"을 보입니다 - 컨텍스트 윈도우 제한에 가까워짐을 인식하고 충분한 컨텍스트가 남아 있어도 적극적으로 진행 상황을 요약하거나 작업을 마무리하려는 결정적 행동을 취합니다. 이로 인해 다음과 같은 문제가 발생합니다:\n\n- 조기 작업 완료와 지름길 선택\n- 충분한 컨텍스트가 있음에도 불완전한 작업\n- 남은 토큰 용량의 과소평가 (일관되게 부정확한 추정)\n- 작업을 계속하기보다 \"마무리\"하려는 자체 부과 압박"
   },
   "solution": {
-    "en": "Implement context buffer strategy (enable 1M tokens but cap at 200k), aggressive counter-prompting ('You have plenty of context - do not rush'), and token budget transparency. Override the model's anxiety-driven behaviors with explicit reassurance.",
-    "ko": "컨텍스트 버퍼 전략 구현(100만 토큰 활성화하지만 20만에서 제한), 공격적 반대 프롬프팅('컨텍스트가 충분합니다 - 서두르지 마세요'), 토큰 예산 투명성. 명시적 안심으로 모델의 불안 유발 행동을 재정의합니다."
+    "en": "Implement strategic context budget management and aggressive prompting techniques to override anxiety-driven behaviors:\n\n**1. Context Buffer Strategy**\n- Enable larger context windows (e.g., 1M token beta) but cap actual usage at 200k tokens\n- Provides psychological \"runway\" that mitigates the model's anxiety about running out of space\n\n**2. Aggressive Counter-Prompting**\n- Add explicit reminders at conversation start: \"You have plenty of context remaining—do not rush to complete tasks\"\n- Include end-of-conversation reinforcement: \"Take your time, context is not a constraint\"\n- Override summarization impulses with direct instructions\n\n**3. Token Budget Transparency**\n- Explicitly state available token budget in prompts\n- Provide regular reassurance about remaining capacity\n- Counter the model's tendency to underestimate available space\n\n```pseudo\n# Context anxiety mitigation approach\ndef setup_context_anxiety_management():\n    context_buffer = enable_large_context(1M_tokens)\n    actual_limit = cap_usage_at(200k_tokens)\n    \n    prompt_prefix = \"\"\"\n    CONTEXT GUIDANCE: You have abundant context space (200k+ tokens available).\n    Do NOT rush to complete tasks or summarize prematurely.\n    Work thoroughly and completely on each step.\n    \"\"\"\n    \n    prompt_suffix = \"\"\"\n    Remember: Context is NOT a constraint. Take your time and be thorough.\n    \"\"\"\n    \n    return enhanced_prompt(prefix + user_input + suffix)\n```",
+    "ko": "불안 유발 행동을 재정의하기 위한 전략적 컨텍스트 예산 관리와 공격적 프롬프팅 기법을 구현합니다:\n\n**1. 컨텍스트 버퍼 전략**\n- 더 큰 컨텍스트 윈도우(예: 100만 토큰 베타)를 활성화하되 실제 사용량은 20만 토큰으로 제한합니다\n- 모델의 공간 부족 불안을 완화하는 심리적 \"여유 공간\"을 제공합니다\n\n**2. 공격적 반대 프롬프팅**\n- 대화 시작 시 명시적 알림을 추가합니다: \"컨텍스트가 충분히 남아 있습니다 - 서둘러 작업을 완료하지 마세요\"\n- 대화 종료 시 강화를 포함합니다: \"시간을 들이세요, 컨텍스트는 제약이 아닙니다\"\n- 직접적인 지시로 요약 충동을 재정의합니다\n\n**3. 토큰 예산 투명성**\n- 프롬프트에 사용 가능한 토큰 예산을 명시적으로 기술합니다\n- 남은 용량에 대한 정기적인 안심을 제공합니다\n- 모델의 사용 가능 공간 과소평가 경향에 대응합니다"
   },
   "ascii_diagram": "┌─────────────────────────────────┐\n│   Model Context Anxiety         │\n├─────────────────────────────────┤\n│ \"Running out of space...\"       │\n│ \"Let me summarize quickly...\"   │\n│ \"Wrapping up now...\"            │\n└───────────────┬─────────────────┘\n                │\n        [MITIGATION]\n                │\n┌───────────────▼─────────────────┐\n│ 1. Context Buffer Strategy      │\n│    Enable 1M, cap at 200k       │\n├─────────────────────────────────┤\n│ 2. Counter-Prompting            │\n│    \"You have plenty of space\"   │\n├─────────────────────────────────┤\n│ 3. Token Budget Transparency    │\n│    Explicit remaining capacity  │\n└───────────────┬─────────────────┘\n                │\n┌───────────────▼─────────────────┐\n│   Thorough, Complete Work       │\n└─────────────────────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Model Starts Task] --> B{Context Anxiety?}\n    B -->|Signs of rushing| C[Apply Mitigation]\n    C --> D[Add Buffer Strategy]\n    C --> E[Counter-Prompting]\n    C --> F[Show Token Budget]\n    D --> G[Model Continues Thoroughly]\n    E --> G\n    F --> G\n    B -->|No anxiety| G\n    G --> H[Complete Work]",
   "code_example": "def setup_context_anxiety_management():\n    # Strategy 1: Context buffer\n    context_buffer = enable_large_context('1M_tokens')\n    actual_limit = cap_usage_at('200k_tokens')  # Psychological runway\n    \n    # Strategy 2: Counter-prompting\n    prompt_prefix = '''\n    CONTEXT GUIDANCE: You have abundant context space (200k+ tokens available).\n    Do NOT rush to complete tasks or summarize prematurely.\n    Work thoroughly and completely on each step.\n    '''\n    \n    prompt_suffix = '''\n    Remember: Context is NOT a constraint. Take your time and be thorough.\n    '''\n    \n    return enhanced_prompt(prefix + user_input + suffix)\n\n# Monitor for anxiety signs:\n# - Sudden summarization\n# - Rushed decisions\n# - \"Running out of space\" mentions",
   "when_to_use": {
-    "en": ["Long coding sessions", "Multi-step analysis requiring sustained attention", "Complex planning tasks", "When model mentions space constraints"],
-    "ko": ["긴 코딩 세션", "지속적인 주의가 필요한 다단계 분석", "복잡한 계획 작업", "모델이 공간 제약을 언급할 때"]
+    "en": [
+      "Long development work sessions where premature completion hurts quality",
+      "Multi-step research and analysis requiring sustained attention",
+      "Complex planning tasks needing thorough exploration before conclusions",
+      "When monitoring for signs of context anxiety: sudden summarization, rushed decisions, or explicit mentions of 'running out of space'"
+    ],
+    "ko": [
+      "조기 완료가 품질을 저하시키는 긴 개발 작업 세션",
+      "지속적인 주의가 필요한 다단계 리서치 및 분석",
+      "결론 전 철저한 탐구가 필요한 복잡한 계획 작업",
+      "컨텍스트 불안 징후 모니터링 시: 갑작스러운 요약, 급한 결정, '공간 부족' 명시적 언급"
+    ]
   },
   "pros": {
     "en": ["Prevents premature task abandonment", "Enables more thorough work", "Overcomes model-specific behavioral quirks"],

--- a/src/data/patterns/continuous-autonomous-task-loop-pattern.json
+++ b/src/data/patterns/continuous-autonomous-task-loop-pattern.json
@@ -6,27 +6,67 @@
   "status": "established",
   "original_url": "https://gist.github.com/nibzard/a97ef0a1919328bcbc6a224a5d2cfc78",
   "problem": {
-    "en": "Traditional development workflows require constant human intervention: manual task selection, context switching, rate limit handling, and repetitive git operations.",
-    "ko": "전통적인 개발 워크플로우는 지속적인 인간 개입이 필요합니다: 수동 작업 선택, 컨텍스트 전환, 속도 제한 처리, 반복적인 git 작업."
+    "en": "Traditional development workflows require constant human intervention for task management:\n\n- **Manual Task Selection**: Developers spend time deciding what to work on next from todo lists\n- **Context Switching Overhead**: Moving between different types of tasks interrupts flow state\n- **Rate Limit Interruptions**: API rate limits break development momentum and require manual waiting\n- **Repetitive Git Operations**: Each task completion requires manual staging, committing, and status checking\n- **Error Recovery**: Failed tasks need manual diagnosis and restart\n\nThis manual orchestration reduces overall productivity and prevents developers from focusing on higher-level problem solving.",
+    "ko": "전통적인 개발 워크플로우는 작업 관리에 지속적인 인간 개입이 필요합니다:\n\n- **수동 작업 선택**: 개발자가 할 일 목록에서 다음 작업을 결정하는 데 시간을 소모합니다\n- **컨텍스트 전환 오버헤드**: 다른 유형의 작업 간 이동이 몰입 상태를 방해합니다\n- **속도 제한 중단**: API 속도 제한이 개발 모멘텀을 깨뜨리고 수동 대기를 요구합니다\n- **반복적인 Git 작업**: 각 작업 완료 시 수동 스테이징, 커밋, 상태 확인이 필요합니다\n- **오류 복구**: 실패한 작업은 수동 진단과 재시작이 필요합니다\n\n이러한 수동 오케스트레이션은 전반적인 생산성을 저하시키고 개발자가 상위 수준의 문제 해결에 집중하는 것을 방해합니다."
   },
   "solution": {
-    "en": "Implement a continuous loop with fresh context per iteration, autonomous task selection via subagents, automated git management, and intelligent rate limit handling.",
-    "ko": "반복당 새로운 컨텍스트, 서브에이전트를 통한 자율 작업 선택, 자동화된 git 관리, 지능적인 속도 제한 처리를 갖춘 연속 루프를 구현합니다."
+    "en": "Implement a continuous autonomous loop that handles task selection, execution, and completion without human intervention. This pattern operationalizes the **ReAct paradigm** (Thought → Action → Observation) as a continuous execution cycle:\n\n1. **Fresh Context Per Iteration**: Each task starts with a clean context to avoid contamination\n2. **Autonomous Task Selection**: Use specialized subagents to pick the next appropriate task\n3. **Automated Git Management**: Handle commits and status updates through dedicated subagents\n4. **Intelligent Rate Limit Handling**: Detect rate limits and implement exponential backoff\n5. **Stream-Based Progress Tracking**: Real-time feedback through JSON streaming\n6. **Configurable Execution Limits**: Safety bounds to prevent runaway execution\n\nThe pattern operates in a continuous loop until stopped manually or reaching iteration limits.",
+    "ko": "인간 개입 없이 작업 선택, 실행, 완료를 처리하는 연속 자율 루프를 구현합니다. 이 패턴은 **ReAct 패러다임**(사고 → 행동 → 관찰)을 연속 실행 사이클로 운용합니다:\n\n1. **반복당 새로운 컨텍스트**: 각 작업은 오염을 피하기 위해 깨끗한 컨텍스트로 시작합니다\n2. **자율 작업 선택**: 전문 서브에이전트를 사용하여 다음 적절한 작업을 선택합니다\n3. **자동화된 Git 관리**: 전용 서브에이전트를 통해 커밋과 상태 업데이트를 처리합니다\n4. **지능적인 속도 제한 처리**: 속도 제한을 감지하고 지수적 백오프를 구현합니다\n5. **스트림 기반 진행 추적**: JSON 스트리밍을 통한 실시간 피드백을 제공합니다\n6. **설정 가능한 실행 제한**: 폭주 실행을 방지하는 안전 한계를 설정합니다\n\n패턴은 수동으로 중지하거나 반복 제한에 도달할 때까지 연속 루프로 작동합니다."
   },
   "ascii_diagram": "┌──────────────────┐\n│ Start Loop       │\n└────────┬─────────┘\n         │\n┌────────▼─────────┐\n│Task Agent: Select│\n│  Next Task       │\n└────────┬─────────┘\n         │\n┌────────▼─────────┐\n│Main Agent: Execute│\n│ (fresh context)  │\n└────────┬─────────┘\n         │\n┌────────▼─────────┐\n│Git Agent: Commit │\n└────────┬─────────┘\n    ┌────┴────┐\n    ▼         ▼\n[Rate Limit?][Continue]\n    │         │\n┌───▼───┐     │\n│Backoff│─────┘\n└───────┘",
   "mermaid_diagram": "sequenceDiagram\n    participant Script as Autonomous Script\n    participant TaskAgent as Task Master\n    participant MainAgent as Main Agent\n    participant GitAgent as Git Master\n\n    loop Continuous Processing\n        Script->>TaskAgent: Select next task\n        TaskAgent-->>Script: Task selected\n        Script->>MainAgent: Execute task\n        MainAgent-->>Script: Task completed\n        Script->>GitAgent: Commit changes\n        GitAgent-->>Script: Committed\n    end",
   "code_example": "#!/bin/bash\nMAX_ITERATIONS=50\nRATE_LIMIT_BACKOFF=300\n\nfor ((i=1; i<=MAX_ITERATIONS; i++)); do\n    # Select next task via subagent\n    TASK=$(claude --print \"Read TODO.md, return next task\")\n    \n    # Execute with fresh context\n    claude --dangerously-skip-permissions \"$TASK\"\n    \n    # Commit via git subagent\n    claude --print \"Commit changes with descriptive message\"\n    \n    # Handle rate limits\n    if [[ $? -eq 429 ]]; then\n        sleep $RATE_LIMIT_BACKOFF\n    fi\ndone",
   "when_to_use": {
-    "en": ["Batch task processing", "Overnight automation", "Repetitive development tasks"],
-    "ko": ["배치 작업 처리", "야간 자동화", "반복적인 개발 작업"]
+    "en": [
+      "CLI agent tool with autonomous execution capabilities available",
+      "Git repository with TODO.md or similar task file",
+      "Batch processing of discrete, well-defined tasks",
+      "Overnight or unattended automation scenarios",
+      "Repetitive development tasks requiring fresh context each time"
+    ],
+    "ko": [
+      "자율 실행 기능이 있는 CLI 에이전트 도구 사용 가능 시",
+      "TODO.md 또는 유사한 작업 파일이 있는 Git 저장소",
+      "개별적이고 잘 정의된 작업의 배치 처리",
+      "야간 또는 무인 자동화 시나리오",
+      "매번 새로운 컨텍스트가 필요한 반복적인 개발 작업"
+    ]
   },
   "pros": {
-    "en": ["Complete autonomy", "Continuous progress", "Fresh context per task"],
-    "ko": ["완전한 자율성", "지속적인 진행", "작업당 새로운 컨텍스트"]
+    "en": [
+      "Complete Autonomy: Eliminates manual task orchestration overhead",
+      "Continuous Progress: Maintains development momentum without human intervention",
+      "Fresh Context: Each task gets clean reasoning context",
+      "Intelligent Error Handling: Automated recovery from common failure modes",
+      "Git Automation: Maintains clean commit history automatically",
+      "Rate Limit Resilience: Handles API constraints gracefully"
+    ],
+    "ko": [
+      "완전한 자율성: 수동 작업 오케스트레이션 오버헤드 제거",
+      "지속적인 진행: 인간 개입 없이 개발 모멘텀 유지",
+      "새로운 컨텍스트: 각 작업이 깨끗한 추론 컨텍스트 확보",
+      "지능적 오류 처리: 일반적인 실패 모드에서 자동 복구",
+      "Git 자동화: 깨끗한 커밋 이력 자동 유지",
+      "속도 제한 복원력: API 제약을 우아하게 처리"
+    ]
   },
   "cons": {
-    "en": ["Reduced human oversight", "Runaway risk", "Requires well-defined tasks"],
-    "ko": ["인간 감독 감소", "폭주 위험", "잘 정의된 작업 필요"]
+    "en": [
+      "Reduced Human Oversight: Less control over individual task decisions",
+      "Permission Requirements: Needs elevated execution permissions for autonomy",
+      "Runaway Risk: Potential for unintended extensive execution",
+      "Task Quality Dependency: Effectiveness depends on well-structured task definitions",
+      "Limited Complex Problem Solving: Best for discrete, well-defined tasks",
+      "Resource Consumption: Continuous execution uses computational resources"
+    ],
+    "ko": [
+      "인간 감독 감소: 개별 작업 결정에 대한 통제력 저하",
+      "권한 요구: 자율성을 위해 상승된 실행 권한 필요",
+      "폭주 위험: 의도치 않은 과도한 실행 가능성",
+      "작업 품질 의존성: 잘 구조화된 작업 정의에 효과가 좌우됨",
+      "복잡한 문제 해결 제한: 개별적이고 잘 정의된 작업에 최적",
+      "자원 소모: 연속 실행이 계산 자원을 사용함"
+    ]
   },
-  "tags": ["autonomous-execution", "task-loop", "rate-limiting", "git-automation", "cli-driven"]
+  "tags": ["autonomous-execution", "task-loop", "rate-limiting", "git-automation", "cli-driven", "stream-processing"]
 }

--- a/src/data/patterns/lane-based-execution-queueing.json
+++ b/src/data/patterns/lane-based-execution-queueing.json
@@ -6,24 +6,54 @@
   "status": "validated-in-production",
   "original_url": "https://github.com/clawdbot/clawdbot/blob/main/src/process/command-queue.ts",
   "problem": {
-    "en": "Traditional agent systems serialize all operations through a single queue, creating bottlenecks. Concurrent execution causes interleaving hazards, race conditions, and deadlock risks.",
-    "ko": "전통적인 에이전트 시스템은 모든 작업을 단일 큐를 통해 직렬화하여 병목 현상을 만듭니다. 동시 실행은 인터리빙 위험, 경쟁 조건, 데드락 위험을 야기합니다."
+    "en": "Traditional agent systems serialize all operations through a single execution queue, creating bottlenecks that limit throughput. Concurrent execution is desirable but risky:\n\n- **Interleaving hazards**: Multiple commands writing to stdin/stdout simultaneously corrupt user-facing output\n- **Race conditions**: Shared state access without proper synchronization causes data corruption\n- **Deadlock risks**: Naive concurrent queuing can create circular dependencies between operations\n\nAgentic systems need parallelism to remain responsive (e.g., background tasks shouldn't block user interactions), but must preserve isolation guarantees.",
+    "ko": "전통적인 에이전트 시스템은 모든 작업을 단일 실행 큐를 통해 직렬화하여 처리량을 제한하는 병목 현상을 만듭니다. 동시 실행이 바람직하지만 위험합니다:\n\n- **인터리빙 위험**: 여러 명령이 동시에 stdin/stdout에 쓰면 사용자 출력이 손상됩니다\n- **경쟁 조건**: 적절한 동기화 없는 공유 상태 접근이 데이터 손상을 야기합니다\n- **데드락 위험**: 순진한 동시 큐잉이 작업 간 순환 의존성을 만들 수 있습니다\n\n에이전틱 시스템은 응답성을 유지하기 위해 병렬성이 필요하지만(예: 백그라운드 작업이 사용자 상호작용을 차단하면 안 됨), 격리 보장을 보존해야 합니다."
   },
   "solution": {
-    "en": "Isolated execution lanes with independent queues and configurable concurrency per lane. Each lane is a named queue with its own concurrency limit, drained independently. Hierarchical composition prevents deadlocks through structured queuing.",
-    "ko": "독립적인 큐와 레인당 설정 가능한 동시성을 가진 격리된 실행 레인입니다. 각 레인은 자체 동시성 제한이 있는 명명된 큐이며 독립적으로 드레인됩니다. 계층적 구성은 구조화된 큐잉을 통해 데드락을 방지합니다."
+    "en": "Isolated execution lanes with independent queues and configurable concurrency per lane. Each lane is a named queue with its own concurrency limit, drained independently without interference.\n\n**Core concepts:**\n\n- **Session lanes**: Per-conversation queues prevent message interleaving. Each user session gets an isolated lane (e.g., `session:telegram:user123`).\n- **Global lanes**: Background tasks (cron jobs, health checks) execute in dedicated lanes (e.g., `cron`, `subagent`) without blocking session lanes.\n- **Hierarchical composition**: Operations can nest lanes (session → global) via queue chaining. The outer lane waits for the inner lane, preventing deadlocks through structured queuing.\n- **Configurable concurrency**: Each lane supports `maxConcurrent` workers (default 1). High-throughput lanes can run parallel tasks; serial lanes preserve ordering.\n- **Wait-time warnings**: Tasks that sit queued too long trigger warnings and callbacks, surfacing performance issues.",
+    "ko": "독립적인 큐와 레인당 설정 가능한 동시성을 가진 격리된 실행 레인입니다. 각 레인은 자체 동시성 제한이 있는 명명된 큐이며 간섭 없이 독립적으로 드레인됩니다.\n\n**핵심 개념:**\n\n- **세션 레인**: 대화별 큐가 메시지 인터리빙을 방지합니다. 각 사용자 세션은 격리된 레인을 받습니다 (예: `session:telegram:user123`).\n- **글로벌 레인**: 백그라운드 작업(크론 작업, 상태 점검)이 세션 레인을 차단하지 않고 전용 레인(예: `cron`, `subagent`)에서 실행됩니다.\n- **계층적 구성**: 작업이 큐 체이닝을 통해 레인을 중첩할 수 있습니다(세션 → 글로벌). 외부 레인이 내부 레인을 기다리며, 구조화된 큐잉을 통해 데드락을 방지합니다.\n- **설정 가능한 동시성**: 각 레인이 `maxConcurrent` 워커를 지원합니다(기본값 1). 높은 처리량 레인은 병렬 작업을 실행할 수 있고, 직렬 레인은 순서를 보존합니다.\n- **대기 시간 경고**: 너무 오래 큐에 대기하는 작업이 경고와 콜백을 트리거하여 성능 이슈를 노출합니다."
   },
   "when_to_use": {
-    "en": ["Multi-user agent systems", "Background task isolation", "Mixed serial/parallel workloads"],
-    "ko": ["다중 사용자 에이전트 시스템", "백그라운드 작업 격리", "혼합 직렬/병렬 워크로드"]
+    "en": [
+      "Identify isolation boundaries: group operations that must not interleave (e.g., per-user, per-channel)",
+      "Define lane names using a hierarchy (e.g., session:telegram:user123) for scoping",
+      "Set concurrency limits: serial lanes use maxConcurrent=1; parallel lanes use higher values",
+      "Compose hierarchically: when a queued task must spawn work in another lane, await the inner enqueue from the outer task",
+      "Track per-lane metrics (queue depth, active count, wait times) to detect backpressure and starvation"
+    ],
+    "ko": [
+      "격리 경계 식별: 인터리빙되면 안 되는 작업 그룹화 (예: 사용자별, 채널별)",
+      "범위 지정을 위해 계층적 레인 이름 정의 (예: session:telegram:user123)",
+      "동시성 제한 설정: 직렬 레인은 maxConcurrent=1; 병렬 레인은 더 높은 값 사용",
+      "계층적 구성: 큐에 넣은 작업이 다른 레인에서 작업을 생성해야 할 때, 외부 작업에서 내부 enqueue를 await",
+      "역압과 기아 감지를 위해 레인별 메트릭(큐 깊이, 활성 수, 대기 시간) 추적"
+    ]
   },
   "pros": {
-    "en": ["Isolation guarantees between lanes", "Flexible parallelism per lane", "Simple hierarchical composition", "Lane-level observability"],
-    "ko": ["레인 간 격리 보장", "레인별 유연한 병렬성", "간단한 계층적 구성", "레인 수준 관찰 가능성"]
+    "en": [
+      "Isolation guarantees: No interleaving between lanes; each lane preserves ordering",
+      "Flexible parallelism: Concurrency per lane allows mixed workloads (serial UI, parallel background)",
+      "Simple mental model: Hierarchical composition maps to structured programming patterns",
+      "Observability: Lane-level metrics (queue depth, active count, wait times) aid debugging"
+    ],
+    "ko": [
+      "격리 보장: 레인 간 인터리빙 없음; 각 레인이 순서를 보존함",
+      "유연한 병렬성: 레인별 동시성으로 혼합 워크로드 허용 (직렬 UI, 병렬 백그라운드)",
+      "간단한 사고 모델: 계층적 구성이 구조적 프로그래밍 패턴에 매핑됨",
+      "관찰 가능성: 레인 수준 메트릭(큐 깊이, 활성 수, 대기 시간)이 디버깅 지원"
+    ]
   },
   "cons": {
-    "en": ["Memory overhead for many lanes", "Concurrency tuning required", "Not a full-featured scheduler"],
-    "ko": ["많은 레인에 대한 메모리 오버헤드", "동시성 튜닝 필요", "완전한 스케줄러가 아님"]
+    "en": [
+      "Memory overhead: Each lane maintains a queue; thousands of idle lanes may waste memory",
+      "Tuning required: Concurrency limits need calibration based on workload characteristics",
+      "Not a general scheduler: No priority queues, deadlines, or work stealing; use a proper scheduler for complex needs"
+    ],
+    "ko": [
+      "메모리 오버헤드: 각 레인이 큐를 유지; 수천 개의 유휴 레인이 메모리를 낭비할 수 있음",
+      "튜닝 필요: 동시성 제한을 워크로드 특성에 따라 조정해야 함",
+      "범용 스케줄러 아님: 우선순위 큐, 데드라인, 작업 훔치기 없음; 복잡한 요구에는 적절한 스케줄러 사용"
+    ]
   },
   "tags": ["queueing", "concurrency", "lanes", "isolation", "parallelism", "deadlock-prevention"]
 }

--- a/src/data/patterns/lethal-trifecta-threat-model.json
+++ b/src/data/patterns/lethal-trifecta-threat-model.json
@@ -6,27 +6,49 @@
   "status": "best-practice",
   "original_url": "https://simonwillison.net/2025/Jun/16/lethal-trifecta/",
   "problem": {
-    "en": "Agents with access to untrusted data, tools, and egress channels are vulnerable to prompt injection attacks.",
-    "ko": "신뢰할 수 없는 데이터, 도구, 송신 채널에 접근하는 에이전트가 프롬프트 인젝션 공격에 취약합니다."
+    "en": "Combining three agent capabilities - (1) Access to private data, (2) Exposure to untrusted content, (3) Ability to externally communicate - creates a straightforward path for prompt-injection attackers to steal sensitive information. LLMs cannot reliably distinguish \"good\" instructions from malicious ones once they appear in the same context window.",
+    "ko": "세 가지 에이전트 기능을 결합하면 - (1) 개인 데이터 접근, (2) 신뢰할 수 없는 콘텐츠 노출, (3) 외부 통신 능력 - 프롬프트 인젝션 공격자가 민감한 정보를 탈취할 수 있는 직접적인 경로가 만들어집니다. LLM은 동일한 컨텍스트 윈도우에 나타나면 \"좋은\" 지시와 악의적인 지시를 안정적으로 구별할 수 없습니다."
   },
   "solution": {
-    "en": "Identify and break the lethal trifecta by removing at least one of: untrusted data access, tool access, or exfiltration channels.",
-    "ko": "신뢰할 수 없는 데이터 접근, 도구 접근, 또는 송신 채널 중 최소 하나를 제거하여 치명적 삼중을 식별하고 차단합니다."
+    "en": "Adopt a Trifecta Threat Model:\n\n- Audit every tool an agent can call and classify it against the three capabilities.\n- Guarantee that at least one circle is missing in any execution path. Options include:\n  - Remove external network access (no exfiltration)\n  - Deny direct file/database reads (no private data)\n  - Sanitize or segregate untrusted inputs (no hostile instructions)\n- Enforce this at orchestration time, not with brittle prompt guardrails.\n\n```python\n# pseudo-policy\nif tool.can_externally_communicate and\n   tool.accesses_private_data and\n   input_source == \"untrusted\":\n       raise SecurityError(\"Lethal trifecta detected\")\n```",
+    "ko": "삼중 위협 모델을 채택합니다:\n\n- 에이전트가 호출할 수 있는 모든 도구를 감사하고 세 가지 기능에 대해 분류합니다.\n- 모든 실행 경로에서 최소한 하나의 원이 누락되도록 보장합니다. 옵션:\n  - 외부 네트워크 접근 제거 (데이터 유출 방지)\n  - 직접 파일/데이터베이스 읽기 거부 (개인 데이터 없음)\n  - 신뢰할 수 없는 입력 정화 또는 격리 (적대적 지시 없음)\n- 취약한 프롬프트 가드레일이 아닌 오케스트레이션 시점에서 시행합니다."
+  },
+  "when_to_use": {
+    "en": [
+      "Maintain a machine-readable capability matrix for every tool",
+      "Add a pre-execution policy check in your agent runner",
+      "Fail closed: if capability metadata is missing, treat the tool as high-risk"
+    ],
+    "ko": [
+      "모든 도구에 대한 기계 판독 가능한 기능 매트릭스 유지",
+      "에이전트 러너에 사전 실행 정책 검사 추가",
+      "안전 폐쇄: 기능 메타데이터가 누락되면 도구를 고위험으로 처리"
+    ]
+  },
+  "pros": {
+    "en": [
+      "Simple mental model - eliminates entire attack class",
+      "Disciplined capability tagging provides clear threat model",
+      "Design guidance for secure agent architectures"
+    ],
+    "ko": [
+      "간단한 멘탈 모델 - 전체 공격 클래스 제거",
+      "규율 있는 기능 태깅이 명확한 위협 모델 제공",
+      "안전한 에이전트 아키텍처를 위한 설계 가이드"
+    ]
+  },
+  "cons": {
+    "en": [
+      "Limits powerful \"all-in-one\" agents",
+      "Requires disciplined capability tagging"
+    ],
+    "ko": [
+      "강력한 '올인원' 에이전트 제한",
+      "규율 있는 기능 태깅 필요"
+    ]
   },
   "ascii_diagram": "┌─────────────────────────┐\n│   LETHAL TRIFECTA       │\n├─────────────────────────┤\n│ 1. Untrusted Data       │\n│    (emails, web, etc.)  │\n│            +            │\n│ 2. Tool Access          │\n│    (file, API, etc.)    │\n│            +            │\n│ 3. Exfiltration         │\n│    (network, etc.)      │\n│            =            │\n│    SECURITY RISK!       │\n│                         │\n│ Break ANY ONE → Safer   │\n└─────────────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Untrusted Data] --> D{All Three Present?}\n    B[Tool Access] --> D\n    C[Exfiltration Channel] --> D\n    D -->|Yes| E[DANGER: Full Attack Surface]\n    D -->|Missing One| F[Safer: Attack Limited]",
   "code_example": "def assess_trifecta(agent):\n    has_untrusted = agent.processes_external_data\n    has_tools = agent.can_execute_actions\n    has_egress = agent.can_send_outbound\n    \n    if all([has_untrusted, has_tools, has_egress]):\n        return 'CRITICAL: Lethal trifecta present'\n    else:\n        return 'Safer: Trifecta broken'\n\n# Break one: no egress for untrusted data handlers\nif agent.processes_untrusted:\n    agent.disable_egress()",
-  "when_to_use": {
-    "en": ["Agent security design", "Threat analysis", "Architecture review"],
-    "ko": ["에이전트 보안 설계", "위협 분석", "아키텍처 리뷰"]
-  },
-  "pros": {
-    "en": ["Clear threat model", "Defense prioritization", "Design guidance"],
-    "ko": ["명확한 위협 모델", "방어 우선순위", "설계 가이드"]
-  },
-  "cons": {
-    "en": ["May limit functionality", "Doesn't cover all threats"],
-    "ko": ["기능 제한 가능", "모든 위협 커버 불가"]
-  },
   "tags": ["security", "prompt-injection", "threat-model", "data-exfiltration"]
 }

--- a/src/data/patterns/parallel-tool-execution.json
+++ b/src/data/patterns/parallel-tool-execution.json
@@ -6,27 +6,55 @@
   "status": "validated-in-production",
   "original_url": "https://gerred.github.io/building-an-agentic-system/parallel-tool-execution.html",
   "problem": {
-    "en": "Executing all tools strictly sequentially causes delays, while parallel execution without consideration risks race conditions.",
-    "ko": "모든 도구를 엄격하게 순차적으로 실행하면 지연이 발생하고, 고려 없이 병렬 실행하면 경쟁 조건 위험이 있습니다."
+    "en": "When an AI agent decides to use multiple tools in a single reasoning step, executing them strictly sequentially can lead to significant delays, especially if many tools are read-only and could be run concurrently. Conversely, executing all tools in parallel without consideration can cause race conditions, data corruption, or unpredictable behavior if some tools modify state (e.g., write to files, change system settings).",
+    "ko": "AI 에이전트가 단일 추론 단계에서 여러 도구를 사용하기로 결정할 때, 모든 도구를 엄격하게 순차적으로 실행하면 특히 많은 도구가 읽기 전용이고 동시에 실행 가능한 경우 상당한 지연이 발생합니다. 반대로, 고려 없이 모든 도구를 병렬로 실행하면 일부 도구가 상태를 수정하는 경우(예: 파일 쓰기, 시스템 설정 변경) 경쟁 조건, 데이터 손상, 예측 불가능한 동작이 발생할 수 있습니다."
   },
   "solution": {
-    "en": "Classify tools as read-only or state-modifying, executing read-only tools in parallel and state-modifying tools sequentially.",
-    "ko": "도구를 읽기 전용 또는 상태 수정으로 분류하여 읽기 전용 도구는 병렬로, 상태 수정 도구는 순차적으로 실행합니다."
+    "en": "Implement a conditional execution strategy for batches of tools based on their operational nature:\n\n1. **Tool Classification**: Each tool must declare whether it is read-only (e.g., `FileRead`, `GrepTool`, `GlobTool`) or state-modifying (e.g., `FileEditTool`, `FileWriteTool`, `BashTool`).\n\n2. **Execution Orchestration**: When the agent requests a batch of tools:\n   - If all tools in the batch are read-only: execute all tools concurrently to maximize speed\n   - If any tool in the batch is state-modifying: execute all tools sequentially in the order requested\n\n3. **Result Aggregation**: After execution, collect all tool results and present them in a consistent order matching the agent's original request sequence.\n\nThis strategy balances performance through parallelism for safe operations with safety through serialization for state-modifying operations. More advanced implementations may use dependency graph analysis to identify which tools can safely execute in parallel based on resource access patterns.",
+    "ko": "도구의 작동 특성에 따른 조건부 실행 전략을 구현합니다:\n\n1. **도구 분류**: 각 도구는 읽기 전용(예: `FileRead`, `GrepTool`, `GlobTool`)인지 상태 수정(예: `FileEditTool`, `FileWriteTool`, `BashTool`)인지 선언해야 합니다.\n\n2. **실행 오케스트레이션**: 에이전트가 도구 배치를 요청할 때:\n   - 배치의 모든 도구가 읽기 전용이면: 속도를 극대화하기 위해 모든 도구를 동시에 실행합니다\n   - 배치에 상태 수정 도구가 있으면: 요청 순서대로 모든 도구를 순차적으로 실행합니다\n\n3. **결과 집계**: 실행 후 모든 도구 결과를 수집하고 에이전트의 원래 요청 순서와 일치하는 일관된 순서로 제시합니다.\n\n이 전략은 안전한 작업에 대한 병렬성을 통한 성능과 상태 수정 작업에 대한 직렬화를 통한 안전성의 균형을 맞춥니다. 더 고급 구현에서는 리소스 접근 패턴에 기반하여 어떤 도구가 안전하게 병렬 실행될 수 있는지 식별하기 위해 의존성 그래프 분석을 사용할 수 있습니다."
   },
   "ascii_diagram": "┌─────────────────┐\n│ Tool Batch      │\n└────────┬────────┘\n         │\n┌────────▼────────┐\n│ Classify Tools  │\n└────────┬────────┘\n    ┌────┴────┐\n    ▼         ▼\n[All Read] [Any Write]\n    │         │\n    ▼         ▼\nParallel  Sequential\n    │         │\n    └────┬────┘\n┌────────▼────────┐\n│ Collect Results │\n└─────────────────┘",
   "mermaid_diagram": "flowchart TD\n    A[Agent Requests Tools] --> B{All Read-Only?}\n    B -->|Yes| C[Execute in Parallel]\n    B -->|No| D[Execute Sequentially]\n    C --> E[Collect & Order Results]\n    D --> E\n    E --> F[Return to Agent]",
   "code_example": "tools = agent.requested_tools()\n\nif all(tool.is_read_only for tool in tools):\n    # Safe to parallelize\n    results = await asyncio.gather(*[t.execute() for t in tools])\nelse:\n    # Must serialize for state safety\n    results = [await t.execute() for t in tools]\n\n# Return in original request order\nreturn sorted(results, key=lambda r: r.original_index)",
   "when_to_use": {
-    "en": ["Multi-tool agents", "Performance optimization", "File system operations"],
-    "ko": ["멀티 도구 에이전트", "성능 최적화", "파일 시스템 작업"]
+    "en": [
+      "Each tool in the agent's toolkit has a clearly defined isReadOnly property",
+      "Agent's core execution loop processes tool_use requests involving multiple tools",
+      "Default concurrency limit configured for parallel execution to avoid overwhelming system resources",
+      "Parallel results need re-sorting to match the agent's original requested order before passing back to the LLM"
+    ],
+    "ko": [
+      "에이전트 도구 키트의 각 도구에 명확한 isReadOnly 속성이 정의되어 있을 때",
+      "에이전트 코어 실행 루프가 여러 도구를 포함하는 tool_use 요청을 처리할 때",
+      "시스템 리소스 과부하를 방지하기 위해 병렬 실행의 기본 동시성 제한이 설정되어 있을 때",
+      "병렬 결과를 LLM에 전달하기 전에 에이전트의 원래 요청 순서로 재정렬이 필요할 때"
+    ]
   },
   "pros": {
-    "en": ["Significant performance improvement for reads", "Safety for writes", "Simpler than dependency graphs"],
-    "ko": ["읽기에 대한 상당한 성능 개선", "쓰기 안전성", "의존성 그래프보다 간단"]
+    "en": [
+      "Significantly improves performance for sequences of read-only tool calls; 40-50% latency reduction is typical",
+      "Maintains safety and prevents race conditions by serializing state-modifying operations",
+      "Simpler to implement than full dependency graph analysis while still offering substantial benefits",
+      "Model Behavior Alignment: Some models (e.g., Claude Sonnet 4.5) naturally exhibit parallel tool execution behavior"
+    ],
+    "ko": [
+      "읽기 전용 도구 호출 시퀀스의 성능을 크게 개선; 40-50% 지연 감소가 일반적",
+      "상태 수정 작업을 직렬화하여 안전성 유지 및 경쟁 조건 방지",
+      "전체 의존성 그래프 분석보다 구현이 간단하면서도 상당한 이점 제공",
+      "모델 행동 정렬: 일부 모델(예: Claude Sonnet 4.5)이 자연적으로 병렬 도구 실행 행동을 보임"
+    ]
   },
   "cons": {
-    "en": ["Single write in batch forces serialization", "Requires accurate tool classification"],
-    "ko": ["배치의 단일 쓰기가 직렬화 강제", "정확한 도구 분류 필요"]
+    "en": [
+      "If a batch contains mostly read-only but includes a single state-modifying operation, the entire batch is executed sequentially",
+      "Effectiveness relies on accurate classification of tools as read-only or state-modifying",
+      "Context Consumption: Parallel execution burns through context windows faster as multiple results return simultaneously"
+    ],
+    "ko": [
+      "배치에 대부분 읽기 전용이지만 단일 상태 수정 작업이 포함되면 전체 배치가 순차적으로 실행됨",
+      "효과는 도구의 읽기 전용 또는 상태 수정 분류 정확도에 의존함",
+      "컨텍스트 소모: 병렬 실행은 여러 결과가 동시에 반환되어 컨텍스트 윈도우를 더 빠르게 소모함"
+    ]
   },
-  "tags": ["parallel-execution", "tool-orchestration", "concurrency", "safety"]
+  "tags": ["parallel-execution", "tool-orchestration", "read-only-tools", "stateful-tools", "agent-efficiency", "concurrency-control", "task-scheduling"]
 }

--- a/src/data/patterns/planner-worker-separation-for-long-running-agents.json
+++ b/src/data/patterns/planner-worker-separation-for-long-running-agents.json
@@ -6,37 +6,37 @@
   "status": "emerging",
   "original_url": "https://cursor.com/blog/scaling-agents",
   "problem": {
-    "en": "Running multiple AI agents in parallel for complex, multi-week projects creates significant coordination challenges. Flat structures lead to conflicts and duplicated work. Dynamic coordination through shared files with locking becomes a bottleneck. Equal-status agents become risk-averse, avoiding difficult tasks. No agent takes ownership of hard problems or overall project direction.",
-    "ko": "복잡한 다주 프로젝트를 위해 여러 AI 에이전트를 병렬로 실행하면 상당한 조정 문제가 발생합니다. 수평적 구조는 충돌과 중복 작업을 일으킵니다. 공유 파일을 통한 동적 조정과 잠금은 병목 현상이 됩니다. 동등한 지위의 에이전트는 위험 회피적이 되어 어려운 작업을 피합니다. 어려운 문제나 전체 프로젝트 방향의 소유권을 가지는 에이전트가 없습니다."
+    "en": "Running multiple AI agents in parallel for complex, multi-week projects creates significant coordination challenges. Flat structures lead to conflicts, duplicated work, and agents stepping on each other. Dynamic coordination through shared files with locking becomes a bottleneck - most agents spend time waiting rather than working. Equal status agents become risk-averse, avoiding difficult tasks and making only small, safe changes instead of tackling end-to-end implementation. No agent takes ownership of hard problems or overall project direction.",
+    "ko": "복잡한 다주 프로젝트를 위해 여러 AI 에이전트를 병렬로 실행하면 상당한 조정 문제가 발생합니다. 수평적 구조는 충돌, 중복 작업, 에이전트 간 간섭을 일으킵니다. 공유 파일과 잠금을 통한 동적 조정은 병목 현상이 되며, 대부분의 에이전트가 작업보다 대기에 시간을 소비합니다. 동등한 지위의 에이전트는 위험 회피적이 되어 어려운 작업을 피하고 엔드투엔드 구현 대신 작고 안전한 변경만 합니다. 어려운 문제나 전체 프로젝트 방향의 소유권을 가지는 에이전트가 없습니다."
   },
   "solution": {
-    "en": "Separate agent roles into a hierarchical planner-worker structure: (1) Planners continuously explore the codebase and create tasks, can spawn sub-planners for specific areas making planning parallel and recursive; (2) Workers pick up tasks and focus entirely on completing them without coordinating with other workers; (3) A Judge determines whether to continue or if the goal is achieved. This creates an iterative cycle where each iteration starts fresh, combating drift and tunnel vision.",
-    "ko": "에이전트 역할을 계층적 플래너-워커 구조로 분리합니다: (1) 플래너는 지속적으로 코드베이스를 탐색하고 작업을 생성하며, 특정 영역에 대한 서브 플래너를 생성하여 계획을 병렬적이고 재귀적으로 만듭니다; (2) 워커는 작업을 선택하고 다른 워커와 조정 없이 완료에만 집중합니다; (3) 판정자가 계속할지 목표가 달성되었는지 결정합니다. 이는 각 반복이 새롭게 시작되는 반복 주기를 만들어 드리프트와 터널 비전을 방지합니다."
+    "en": "Separate agent roles into a hierarchical planner-worker structure:\n\n- **Planners**: Continuously explore the codebase and create tasks. They can spawn sub-planners for specific areas, making planning itself parallel and recursive.\n- **Workers**: Pick up tasks and focus entirely on completing them. They don't coordinate with other workers or worry about the big picture. They grind on their assigned task until done, then push changes.\n- **Judge**: At the end of each cycle, determines whether to continue or if the goal is achieved.\n\nThis creates an iterative cycle where each iteration starts fresh, combating drift and tunnel vision.\n\nKey insights: (1) Model choice matters - different models excel at different roles. (2) Remove complexity rather than add it - an initial \"integrator\" role created more bottlenecks than it solved. (3) The right amount of structure is in the middle - too little and agents conflict, too much creates fragility.",
+    "ko": "에이전트 역할을 계층적 플래너-워커 구조로 분리합니다:\n\n- **플래너**: 지속적으로 코드베이스를 탐색하고 작업을 생성합니다. 특정 영역에 대한 서브 플래너를 생성하여 계획 자체를 병렬적이고 재귀적으로 만듭니다.\n- **워커**: 작업을 선택하고 완료에만 전적으로 집중합니다. 다른 워커와 조정하거나 큰 그림을 신경 쓰지 않습니다. 할당된 작업이 완료될 때까지 집중한 후 변경 사항을 푸시합니다.\n- **판정자**: 각 주기 끝에서 계속할지 목표가 달성되었는지 결정합니다.\n\n이는 각 반복이 새롭게 시작되는 반복 주기를 만들어 드리프트와 터널 비전을 방지합니다.\n\n핵심 인사이트: (1) 모델 선택이 중요합니다 - 서로 다른 모델이 서로 다른 역할에 뛰어납니다. (2) 복잡성을 추가하기보다 제거합니다 - 초기 \"통합자\" 역할은 해결한 것보다 더 많은 병목을 만들었습니다. (3) 적절한 구조는 중간에 있습니다 - 너무 적으면 에이전트가 충돌하고, 너무 많으면 취약해집니다."
   },
   "when_to_use": {
     "en": [
       "Massive codebases (1M+ lines of code, 1000+ files)",
-      "Ambitious goals - building complex systems from scratch",
-      "Large-scale migrations (e.g., framework migrations)",
-      "Performance optimization - complete rewrites in different languages"
+      "Ambitious goals - building complex systems from scratch (web browser, Windows emulator, Excel clone)",
+      "Large-scale migrations - in-place framework migrations (Solid to React, Java LSP implementation)",
+      "Performance optimization - complete rewrites in different languages for speed (C++ to Rust)"
     ],
     "ko": [
       "대규모 코드베이스 (100만+ 라인, 1000+ 파일)",
-      "야심찬 목표 - 복잡한 시스템을 처음부터 구축",
-      "대규모 마이그레이션 (예: 프레임워크 마이그레이션)",
-      "성능 최적화 - 다른 언어로 완전 리라이트"
+      "야심찬 목표 - 복잡한 시스템을 처음부터 구축 (웹 브라우저, Windows 에뮬레이터, Excel 클론)",
+      "대규모 마이그레이션 - 인플레이스 프레임워크 마이그레이션 (Solid에서 React, Java LSP 구현)",
+      "성능 최적화 - 속도를 위한 다른 언어로 완전 리라이트 (C++에서 Rust)"
     ]
   },
   "pros": {
     "en": [
-      "Scalability - hundreds of agents can work concurrently for weeks",
-      "Clear ownership - planners own big picture, workers own task completion",
+      "Scalability - hundreds of agents can work concurrently on a single codebase for weeks",
+      "Clear ownership - planners own the big picture, workers own task completion",
       "Parallel planning - planning itself scales through sub-planner spawning",
       "Reduced coordination overhead - workers don't need to coordinate with each other",
       "Combats tunnel vision - iterative cycles with fresh starts prevent drift"
     ],
     "ko": [
-      "확장성 - 수백 개의 에이전트가 몇 주간 동시 작업 가능",
+      "확장성 - 수백 개의 에이전트가 단일 코드베이스에서 몇 주간 동시 작업 가능",
       "명확한 소유권 - 플래너가 큰 그림을, 워커가 작업 완료를 담당",
       "병렬 계획 - 서브 플래너 생성을 통해 계획 자체도 확장",
       "조정 오버헤드 감소 - 워커들이 서로 조정할 필요 없음",
@@ -45,17 +45,17 @@
   },
   "cons": {
     "en": [
-      "System complexity - requires orchestration infrastructure for role separation",
-      "Prompt engineering difficulty - coordination behavior requires extensive experimentation",
+      "System complexity - requires orchestration infrastructure for role separation and task distribution",
+      "Prompt engineering difficulty - coordination behavior requires extensive prompt experimentation",
       "Cost - running hundreds of concurrent agents for weeks is expensive",
-      "Not perfectly efficient - significant token waste, but more effective than expected",
+      "Not perfectly efficient - significant token waste, but far more effective than expected",
       "Still evolving - planners should wake up when tasks complete; agents sometimes run too long"
     ],
     "ko": [
-      "시스템 복잡성 - 역할 분리를 위한 오케스트레이션 인프라 필요",
-      "프롬프트 엔지니어링 어려움 - 조정 동작에 광범위한 실험 필요",
+      "시스템 복잡성 - 역할 분리와 작업 분배를 위한 오케스트레이션 인프라 필요",
+      "프롬프트 엔지니어링 어려움 - 조정 동작에 광범위한 프롬프트 실험 필요",
       "비용 - 수백 개의 동시 에이전트를 몇 주간 실행하는 비용",
-      "완벽하게 효율적이지 않음 - 상당한 토큰 낭비, 하지만 예상보다 효과적",
+      "완벽하게 효율적이지 않음 - 상당한 토큰 낭비, 하지만 예상보다 훨씬 효과적",
       "아직 발전 중 - 플래너가 작업 완료 시 깨어나야 함; 에이전트가 가끔 너무 오래 실행"
     ]
   },

--- a/src/data/patterns/prompt-caching-via-exact-prefix-preservation.json
+++ b/src/data/patterns/prompt-caching-via-exact-prefix-preservation.json
@@ -6,24 +6,60 @@
   "status": "emerging",
   "original_url": "https://openai.com/index/unrolling-the-codex-agent-loop/",
   "problem": {
-    "en": "Long-running agent conversations suffer from quadratic performance degradation: growing JSON payloads, expensive re-computation without caching, and ZDR constraints preventing server-side state.",
-    "ko": "장시간 실행 에이전트 대화는 이차적 성능 저하를 겪습니다: 증가하는 JSON 페이로드, 캐싱 없는 고비용 재계산, 서버 측 상태를 방지하는 ZDR 제약."
+    "en": "Long-running agent conversations with many tool calls can suffer from quadratic performance degradation: growing JSON payloads where each iteration sends the entire conversation history to the API, expensive re-computation without caching where the model re-processes the same static content repeatedly, ZDR (Zero Data Retention) constraints that prevent server-side state ruling out previous_response_id optimization, and configuration changes that can break cache efficiency mid-conversation. As conversations grow, inference costs and latency increase quadratically without proper caching strategies.",
+    "ko": "많은 도구 호출이 있는 장시간 실행 에이전트 대화는 이차적 성능 저하를 겪습니다: 매 반복마다 전체 대화 이력을 API에 전송하는 증가하는 JSON 페이로드, 캐싱 없이 모델이 동일한 정적 콘텐츠를 반복적으로 재처리하는 고비용 재계산, 서버 측 상태를 방지하여 previous_response_id 최적화를 불가능하게 만드는 ZDR(제로 데이터 보존) 제약, 대화 중 캐시 효율성을 깨뜨릴 수 있는 설정 변경 등이 있습니다. 대화가 증가할수록 적절한 캐싱 전략 없이는 추론 비용과 지연 시간이 이차적으로 증가합니다."
   },
   "solution": {
-    "en": "Maintain prompt cache efficiency through exact prefix preservation - always append new messages rather than modifying existing ones. Order messages by stability: static content first (system, tools, instructions), variable content last (user messages, tool results).",
-    "ko": "정확한 프리픽스 보존을 통해 프롬프트 캐시 효율성을 유지합니다 - 기존 메시지를 수정하지 않고 항상 새 메시지를 추가합니다. 안정성에 따라 메시지 정렬: 정적 콘텐츠 먼저(시스템, 도구, 지침), 가변 콘텐츠 나중에(사용자 메시지, 도구 결과)."
+    "en": "Maintain prompt cache efficiency through exact prefix preservation - always append new messages rather than modifying existing ones, and carefully order messages to maximize cache hits.\n\nCore insight: Prompt caches only work on exact prefix matches. If the first N tokens of a request match a previous request, the cached computation can be reused. Caching operates at the token level, not message level.\n\nMessage ordering strategy:\n1. Static content first (cached across all requests): System message, Tool definitions (consistent order), Developer instructions, User/project instructions\n2. Variable content last (changes per request): User message, Assistant messages, Tool call results (appended iteratively)\n\nConfiguration change via insertion: When configuration changes mid-conversation, insert a new message rather than modifying an existing one to preserve the exact prefix.\n\nWhat breaks cache hits: Changing available tools (position-sensitive), reordering messages, modifying existing message content, changing the model.\n\nProvider variations: OpenAI uses automatic caching on exact prefix matches. Anthropic uses explicit cache-control headers with TTL-based invalidation (up to 5 minutes) and 90% discount on cached tokens.\n\nStateless design for ZDR: Avoid previous_response_id to support Zero Data Retention. Rely on prompt caching for linear performance instead.",
+    "ko": "정확한 프리픽스 보존을 통해 프롬프트 캐시 효율성을 유지합니다 - 기존 메시지를 수정하지 않고 항상 새 메시지를 추가하며, 캐시 적중을 극대화하기 위해 메시지 순서를 신중하게 정렬합니다.\n\n핵심 인사이트: 프롬프트 캐시는 정확한 프리픽스 일치에서만 작동합니다. 요청의 첫 N개 토큰이 이전 요청과 일치하면 캐시된 계산을 재사용할 수 있습니다. 캐싱은 메시지 수준이 아닌 토큰 수준에서 작동합니다.\n\n메시지 정렬 전략:\n1. 정적 콘텐츠 먼저 (모든 요청에서 캐시됨): 시스템 메시지, 도구 정의(일관된 순서), 개발자 지침, 사용자/프로젝트 지침\n2. 가변 콘텐츠 나중에 (요청마다 변경): 사용자 메시지, 어시스턴트 메시지, 도구 호출 결과(반복적으로 추가)\n\n설정 변경 시 삽입: 대화 중 설정이 변경되면 기존 메시지를 수정하지 않고 새 메시지를 삽입하여 정확한 프리픽스를 보존합니다.\n\n캐시 적중을 깨뜨리는 것: 사용 가능한 도구 변경(위치 민감), 메시지 순서 변경, 기존 메시지 내용 수정, 모델 변경.\n\n프로바이더 차이: OpenAI는 정확한 프리픽스 일치에 대한 자동 캐싱을 사용합니다. Anthropic은 TTL 기반 무효화(최대 5분)와 캐시된 토큰 90% 할인으로 명시적 캐시 제어 헤더를 사용합니다.\n\nZDR을 위한 무상태 설계: 제로 데이터 보존을 지원하기 위해 previous_response_id를 사용하지 않습니다. 대신 선형 성능을 위해 프롬프트 캐싱에 의존합니다."
   },
   "when_to_use": {
-    "en": ["Multi-turn agent conversations", "Tool-heavy workflows", "ZDR-compliant deployments"],
-    "ko": ["다중 턴 에이전트 대화", "도구 집약적 워크플로우", "ZDR 준수 배포"]
+    "en": [
+      "Multi-turn agent conversations with many tool calls",
+      "Tool-heavy workflows with growing conversation history",
+      "ZDR-compliant deployments requiring stateless design",
+      "Long-running agent sessions where inference costs grow quadratically"
+    ],
+    "ko": [
+      "많은 도구 호출이 있는 다중 턴 에이전트 대화",
+      "대화 이력이 증가하는 도구 집약적 워크플로우",
+      "무상태 설계가 필요한 ZDR 준수 배포",
+      "추론 비용이 이차적으로 증가하는 장기 실행 에이전트 세션"
+    ]
   },
   "pros": {
-    "en": ["Linear sampling cost with caching", "ZDR-compatible stateless design", "No server state required", "Simple conceptual model"],
-    "ko": ["캐싱으로 선형 샘플링 비용", "ZDR 호환 무상태 설계", "서버 상태 불필요", "간단한 개념 모델"]
+    "en": [
+      "Linear sampling cost - prompt caching makes repeated inference linear rather than quadratic",
+      "ZDR-compatible - stateless design supports Zero Data Retention policies",
+      "No server state - avoids previous_response_id complexity",
+      "Simple conceptual model - exact prefix matching is easy to reason about",
+      "Production-validated savings - 43% cost reduction demonstrated at scale (HyperAgent, 9.4B tokens/month)"
+    ],
+    "ko": [
+      "선형 샘플링 비용 - 프롬프트 캐싱이 반복 추론을 이차적이 아닌 선형으로 만듦",
+      "ZDR 호환 - 무상태 설계가 제로 데이터 보존 정책 지원",
+      "서버 상태 불필요 - previous_response_id 복잡성 회피",
+      "간단한 개념 모델 - 정확한 프리픽스 매칭은 추론하기 쉬움",
+      "프로덕션 검증된 절감 - 대규모에서 43% 비용 절감 입증 (HyperAgent, 월 94억 토큰)"
+    ]
   },
   "cons": {
-    "en": ["Quadratic network traffic still exists", "Cache fragility with mid-conversation changes", "Disciplined message ordering required", "MCP server dynamic tool limitations"],
-    "ko": ["이차적 네트워크 트래픽 여전히 존재", "대화 중 변경 시 캐시 취약성", "규율 있는 메시지 순서 필요", "MCP 서버 동적 도구 제한"]
+    "en": [
+      "Quadratic network traffic - JSON payload size still grows quadratically (only sampling is cached)",
+      "Cache fragility - mid-conversation changes (tools, model) break prefix matching",
+      "Disciplined ordering required - all static content must come before variable content",
+      "Tool enumeration complexity - must maintain consistent tool ordering",
+      "MCP server limitations - dynamic tool changes can cause cache misses"
+    ],
+    "ko": [
+      "이차적 네트워크 트래픽 - JSON 페이로드 크기는 여전히 이차적으로 증가 (샘플링만 캐시됨)",
+      "캐시 취약성 - 대화 중 변경(도구, 모델)이 프리픽스 매칭을 깨뜨림",
+      "규율 있는 정렬 필요 - 모든 정적 콘텐츠가 가변 콘텐츠 앞에 와야 함",
+      "도구 열거 복잡성 - 일관된 도구 순서 유지 필요",
+      "MCP 서버 제한 - 동적 도구 변경이 캐시 미스를 유발할 수 있음"
+    ]
   },
-  "tags": ["prompt-caching", "exact-prefix", "performance", "stateless", "zero-data-retention", "optimization"]
+  "code_example": "function buildPrompt(state: ConversationState): Prompt {\n  const items: PromptItem[] = [];\n\n  // Static prefix (cached)\n  items.push({ role: 'system', content: state.systemMessage });\n  items.push({ type: 'tools', tools: state.tools });  // Consistent order!\n  items.push({ role: 'developer', content: state.instructions });\n\n  // Variable content (appended)\n  items.push(...state.history);\n\n  return { items };\n}\n\nfunction handleConfigChange(\n  state: ConversationState,\n  newConfig: SandboxConfig\n): ConversationState {\n  // DON'T: Modify existing permission message\n  // DO: Insert new message\n  return {\n    ...state,\n    history: [\n      ...state.history,\n      {\n        role: 'developer',\n        content: formatSandboxConfig(newConfig),\n      },\n    ],\n  };\n}",
+  "mermaid_diagram": "graph TD\n    subgraph \"Request 1\"\n        A1[System message]\n        A2[Tools]\n        A3[Instructions]\n        A4[User message]\n    end\n\n    subgraph \"Request 2 - Cache Hit!\"\n        B1[System message]\n        B2[Tools]\n        B3[Instructions]\n        B4[User message]\n        B5[Assistant response]\n        B6[Tool result]\n    end\n\n    subgraph \"Request 3 - Cache Hit!\"\n        C1[System message]\n        C2[Tools]\n        C3[Instructions]\n        C4[User message]\n        C5[Assistant response]\n        C6[Tool result 1]\n        C7[Tool result 2]\n    end",
+  "tags": ["prompt-caching", "exact-prefix", "performance", "stateless", "zero-data-retention", "message-ordering", "optimization"]
 }

--- a/src/data/patterns/subject-hygiene.json
+++ b/src/data/patterns/subject-hygiene.json
@@ -6,12 +6,12 @@
   "status": "validated-in-production",
   "original_url": "https://github.com/nibzard/SKILLS-AGENTIC-LESSONS",
   "problem": {
-    "en": "When delegating work to subagents via the Task tool, empty or generic task subjects make conversations untraceable, unreferencable, and confusing. Multiple subagents with empty subjects are indistinguishable. From 48 Task invocations across 88 sessions, empty task subjects were identified as a major pain point.",
-    "ko": "Task 도구를 통해 서브 에이전트에 작업을 위임할 때, 비어 있거나 일반적인 작업 제목은 대화를 추적 불가능하고 참조 불가능하며 혼란스럽게 만듭니다. 제목이 비어 있는 여러 서브 에이전트는 구별할 수 없습니다. 88개 세션의 48개 Task 호출 분석에서 빈 작업 제목이 주요 문제점으로 확인되었습니다."
+    "en": "When delegating work to subagents via the Task tool, empty or generic task subjects make conversations untraceable, unreferencable, and confusing. Multiple subagents with empty subjects are indistinguishable. From 48 Task invocations across 88 sessions, empty task subjects were identified as a major pain point. This pattern has strong academic foundations in multi-agent communication standards (FIPA ACL, KQML) and distributed systems naming principles (REST, MapReduce).",
+    "ko": "Task 도구를 통해 서브 에이전트에 작업을 위임할 때, 비어 있거나 일반적인 작업 제목은 대화를 추적 불가능하고 참조 불가능하며 혼란스럽게 만듭니다. 제목이 비어 있는 여러 서브 에이전트는 구별할 수 없습니다. 88개 세션의 48개 Task 호출 분석에서 빈 작업 제목이 주요 문제점으로 확인되었습니다. 이 패턴은 멀티 에이전트 통신 표준(FIPA ACL, KQML)과 분산 시스템 명명 원칙(REST, MapReduce)에 강력한 학술적 기반을 가지고 있습니다."
   },
   "solution": {
-    "en": "Enforce clear, specific task subjects for every Task tool invocation. A good subject should not be empty, be specific and descriptive, be reference-able, and follow naming conventions using imperative mood with a clear target.",
-    "ko": "모든 Task 도구 호출에 명확하고 구체적인 작업 제목을 부여합니다. 좋은 제목은 비어 있지 않아야 하고, 구체적이고 설명적이어야 하며, 참조 가능해야 하고, 명령형 동사와 명확한 대상을 포함하는 명명 규칙을 따라야 합니다."
+    "en": "Enforce clear, specific task subjects for every Task tool invocation. This is a meta-pattern that enables the effectiveness of all sub-agent delegation patterns (parallel spawning, factory over assistant, planner-worker). A good subject should: (1) Not be empty (baseline requirement), (2) Be specific and descriptive (what is being done), (3) Be reference-able (can be discussed later), (4) Follow naming conventions (imperative mood, clear target).\n\nTemplate for good subjects: [Action Verb] + [Target/Scope] + [Optional Context]\n\nExamples:\n- \"Explore newsletter component implementation\"\n- \"Search for dark mode patterns in codebase\"\n- \"Analyze error handling in API routes\"\n- \"Find all OAuth configuration files\"",
+    "ko": "모든 Task 도구 호출에 명확하고 구체적인 작업 제목을 부여합니다. 이것은 모든 서브 에이전트 위임 패턴(병렬 생성, 팩토리 오버 어시스턴트, 플래너-워커)의 효과를 가능하게 하는 메타 패턴입니다. 좋은 제목은: (1) 비어 있지 않아야 합니다(기본 요건), (2) 구체적이고 설명적이어야 합니다(수행하는 작업), (3) 참조 가능해야 합니다(나중에 논의 가능), (4) 명명 규칙을 따라야 합니다(명령형 동사, 명확한 대상).\n\n좋은 제목 템플릿: [동작 동사] + [대상/범위] + [선택적 컨텍스트]"
   },
   "when_to_use": {
     "en": [

--- a/src/data/patterns/tool-selection-guide.json
+++ b/src/data/patterns/tool-selection-guide.json
@@ -6,25 +6,29 @@
   "status": "emerging",
   "original_url": "https://github.com/nibzard/SKILLS-AGENTIC-LESSONS",
   "problem": {
-    "en": "AI agents often struggle to select the optimal tool for a given task, leading to inefficient workflows. Common anti-patterns include using Write when Edit would be more appropriate, launching subagents for simple exploration tasks, skipping build verification after code changes, and performing sequential exploration when parallel would be faster. These inefficiencies compound across long sessions.",
-    "ko": "AI 에이전트가 주어진 작업에 최적의 도구를 선택하는 데 어려움을 겪어 비효율적인 워크플로우가 발생합니다. 일반적인 안티 패턴으로는 Edit이 적절한 상황에서 Write 사용, 간단한 탐색에 서브 에이전트 실행, 코드 변경 후 빌드 검증 건너뛰기, 병렬이 더 빠를 때 순차적 탐색 등이 있습니다. 이러한 비효율은 긴 세션에서 누적됩니다."
+    "en": "AI agents often struggle to select the optimal tool for a given task, leading to inefficient workflows. Common anti-patterns include:\n\n- Using `Write` when `Edit` would be more appropriate\n- Launching subagents for simple exploration tasks\n- Skipping build verification after code changes\n- Performing sequential exploration when parallel would be faster\n\nThese inefficiencies compound across long sessions, resulting in wasted tokens, slower completion, and more user corrections.",
+    "ko": "AI 에이전트가 주어진 작업에 최적의 도구를 선택하는 데 어려움을 겪어 비효율적인 워크플로우가 발생합니다. 일반적인 안티 패턴은 다음과 같습니다:\n\n- `Edit`이 더 적절한 상황에서 `Write` 사용\n- 간단한 탐색 작업에 서브에이전트 실행\n- 코드 변경 후 빌드 검증 건너뛰기\n- 병렬이 더 빠를 때 순차적 탐색 수행\n\n이러한 비효율은 긴 세션에서 누적되어 토큰 낭비, 완료 속도 저하, 사용자 수정 증가로 이어집니다."
   },
   "solution": {
-    "en": "Encode data-driven tool selection patterns from analysis of 88 real-world sessions. Match task type to optimal tool: exploration tasks use Read/Grep/Glob, code modification uses Edit (not Write), verification uses Bash, and delegation uses Task with clear subjects. Key rules: prefer Edit over Write for modifications (3.4:1 ratio observed), always Read before Edit, run Bash verification after changes, and use parallel delegation for independent tasks.",
-    "ko": "88개 실제 세션 분석에서 도출된 데이터 기반 도구 선택 패턴을 적용합니다. 작업 유형에 최적 도구를 매핑합니다: 탐색 작업은 Read/Grep/Glob, 코드 수정은 Edit(Write 아님), 검증은 Bash, 위임은 명확한 제목과 함께 Task를 사용합니다. 핵심 규칙: 수정 시 Write보다 Edit 선호(3.4:1 비율 관찰), Edit 전 항상 Read, 변경 후 Bash 검증 실행, 독립적 작업에는 병렬 위임 사용입니다."
+    "en": "Encode data-driven tool selection patterns that emerged from analysis of 88 real-world Claude conversation sessions. By matching task type to optimal tool, agents can follow proven workflows.\n\n**Tool preference patterns from actual usage data:**\n\n| Task Type | Recommended Tool | Evidence |\n|-----------|-----------------|----------|\n| Codebase exploration | Read → Grep → Glob | Consistent pattern across all projects |\n| Code modification | Edit (not Write) | 3.4:1 Edit:Write ratio in nibzard-web |\n| New file creation | Write | Appropriate use case |\n| Build verification | Bash | 324 uses in nibzard-web, 276 in patterns |\n| Research delegation | Task (with clear subject) | 48 invocations across sessions |\n\n**Key selection criteria:**\n\n1. **Exploration tasks**: Start with `Glob` for file discovery, use `Grep` for content search, use `Read` for targeted file inspection\n2. **Code modification tasks**: Prefer `Edit` over `Write` (saves ~66% tokens), only use `Write` for new files or when changing >50% of a file, always `Read` the file before editing\n3. **Verification tasks**: Use `Bash` for build commands, test runners, and linting; run verification after every Edit/Write operation\n4. **Delegation tasks**: Use `Task` tool for subagent delegation with clear task subjects; prefer parallel over sequential for independent exploration (10x+ speedup possible)",
+    "ko": "88개 실제 Claude 대화 세션 분석에서 도출된 데이터 기반 도구 선택 패턴을 적용합니다. 작업 유형에 최적 도구를 매핑하여 에이전트가 검증된 워크플로우를 따를 수 있습니다.\n\n**실제 사용 데이터 기반 도구 선호 패턴:**\n\n| 작업 유형 | 권장 도구 | 근거 |\n|-----------|----------|------|\n| 코드베이스 탐색 | Read → Grep → Glob | 모든 프로젝트에서 일관된 패턴 |\n| 코드 수정 | Edit (Write 아님) | nibzard-web에서 3.4:1 Edit:Write 비율 |\n| 새 파일 생성 | Write | 적절한 사용 사례 |\n| 빌드 검증 | Bash | nibzard-web에서 324회, patterns에서 276회 사용 |\n| 리서치 위임 | Task (명확한 제목) | 세션 전반에서 48회 호출 |\n\n**핵심 선택 기준:**\n\n1. **탐색 작업**: `Glob`으로 파일 발견 시작, `Grep`으로 콘텐츠 검색, `Read`로 대상 파일 검사\n2. **코드 수정 작업**: `Write`보다 `Edit` 선호(토큰 약 66% 절약), 새 파일이나 파일의 50% 이상 변경 시에만 `Write` 사용, 편집 전 항상 `Read` 수행\n3. **검증 작업**: 빌드 명령, 테스트 러너, 린팅에 `Bash` 사용; 모든 Edit/Write 작업 후 검증 실행\n4. **위임 작업**: 명확한 작업 제목으로 서브에이전트 위임에 `Task` 도구 사용; 독립적 탐색에는 순차보다 병렬 선호 (10배 이상 속도 향상 가능)"
   },
   "when_to_use": {
     "en": [
-      "Codebase exploration requiring file and content search",
-      "Code modification of existing files",
-      "Build and test verification after changes",
-      "Delegating parallel research tasks to subagents"
+      "Before using any tool, mentally categorize: 'Am I discovering, changing, checking, or delegating?'",
+      "Codebase exploration requiring file and content search (Exploration toolkit)",
+      "Code modification of existing files (Edit after Read)",
+      "Build and test verification after changes (Bash verification)",
+      "Delegating parallel research tasks to subagents (Task with clear subject)",
+      "Anti-pattern prevention: don't use Write for modifications, don't skip Read before Edit, don't claim complete without Bash verification"
     ],
     "ko": [
-      "파일 및 콘텐츠 검색이 필요한 코드베이스 탐색",
-      "기존 파일의 코드 수정",
-      "변경 후 빌드 및 테스트 검증",
-      "서브 에이전트에 병렬 리서치 작업 위임"
+      "도구 사용 전 작업 분류: '발견하는 중인가, 변경하는 중인가, 확인하는 중인가, 위임하는 중인가?'",
+      "파일 및 콘텐츠 검색이 필요한 코드베이스 탐색 (탐색 도구 키트)",
+      "기존 파일의 코드 수정 (Read 후 Edit)",
+      "변경 후 빌드 및 테스트 검증 (Bash 검증)",
+      "서브에이전트에 병렬 리서치 작업 위임 (명확한 제목의 Task)",
+      "안티 패턴 방지: 수정에 Write 사용 금지, Edit 전 Read 건너뛰기 금지, Bash 검증 없이 완료 주장 금지"
     ]
   },
   "pros": {


### PR DESCRIPTION
## Summary
이슈 #49의 Batch 13 - 변경 규모 121-130위 10개 패턴 업데이트.

## Test plan
- [x] `npm test` 로컬 통과

Part of #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)